### PR TITLE
Refactor shared functionality between the two tone marks scripts

### DIFF
--- a/Tone_Marks.pub.user.js
+++ b/Tone_Marks.pub.user.js
@@ -1,14 +1,17 @@
 // ==UserScript==
 // @name         Tone Marks
 // @namespace    http://tampermonkey.net/
-// @version      4.0.6
-// @description  Add tone marks on Ao3 works, and add quick audio guide clips were available
+// @version      4.1.1
+// clang-format off
+// @description  Add tone marks on Ao3 works
 // @author       Cathalinaheart, irrationalpie7
 // @match        https://archiveofourown.org/*
-// clang-format off
 // @updateURL    https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/Tone_Marks_withAudio.pub.user.js
 // @downloadURL  https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/Tone_Marks_withAudio.pub.user.js
 //
+// @require      replace.js
+// @require      check-fandoms.js
+// @require      mark-tones.js
 // Generic and per-fandom replacement rules:
 // @resource     generic https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/generic.txt
 // @resource     guardian https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/guardian.txt
@@ -20,270 +23,13 @@
 // @resource     svsss https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/svsss.txt
 // @resource     jwqs https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/jwqs.txt
 // @resource     erha https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/erha.txt
-// @resource     audioplay https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/playaudio.min.js
-// @resource     IMPORTED_CSS https://fonts.googleapis.com/icon?family=Material+Icons
 // clang-format on
-// @grant unsafeWindow
 // @grant GM.getResourceUrl
-// @grant GM_xmlhttpRequest
-// @grant GM_getResourceText
 // @grant GM_addStyle
 // ==/UserScript==
 
-(function() {
-'use strict';
+(async function() {
+  'use strict';
 
-async function doTheThing() {
-  // Url of the ao3 page.
-  const url = unsafeWindow.location.href;
-  // Document structure of the ao3 page.
-  const document = unsafeWindow.document;
-
-  // Check whether this page is an ao3 work.
-  const works_regex = /https:\/\/archiveofourown\.org(\/.*)?\/works\/[0-9]+.*/;
-  // Check whether it's an editing page.
-  const edit_page_regex = /\/works\/[0-9]+\/edit/;
-
-  if (url.match(works_regex) !== null) {
-    if (url.match(edit_page_regex) === null && !url.includes('works/new')) {
-      console.log('On a works page, potentially making pinyin replacements...')
-          // Don't make replacements on the new work/edit work (tag) page,
-          // that sounds confusing.
-          await doReplacements(document.getElementById('main'));
-    }
-  } else {
-    console.log(
-        'Not on a works page; going to try to do pinyin replacement per blurb...')
-    // Get all the work/series blurbs
-    const blurbs = Array.from(document.querySelectorAll('.blurb'));
-    for (let i = 0; i < blurbs.length; i++) {
-      await doReplacements(blurbs[i]);
-    }
-  }
-
-  // Clean up re-replacements.
-  const replacements = Array.from(document.querySelectorAll('.replacement'));
-  replacements.forEach(function(span) {
-    span.innerHTML = span.dataset.new;
-  });
-}
-doTheThing();
-
-/**
- * Replaces special html characters.
- * @param {string} str
- * @returns {string}
- */
-function escaped(unsafe) {
-  return (unsafe + '')
-      .replaceAll('&', '&amp;')
-      .replaceAll('<', '&lt;')
-      .replaceAll('>', '&gt;')
-      .replaceAll('"', '&quot;')
-      .replaceAll('\'', '&#039;');
-}
-
-/**
- * Returns a regex to match a sequence of words, allowing an optional
- * dash (-) or space ( ) between each word. The beginning and end of the
- * matching sequence must be at a word boundary.
- *
- * The regex will also match an incomplete html tag preceding the match,
- * which you can check for to avoid replacing within an html tag's
- * attributes.
- *
- * @param {string[]} words
- * @return {RegExp}
- */
-function wordsMatchRegex(words) {
-  return new RegExp(
-      '(<[a-z]+ [^>]*)?\\b(' +
-          words
-              .map(
-                  word =>
-                      escaped(word).replace(/([.?*+^$[\]\\(){}|])/g, '\\$1'))
-              .join('( |-)?') +
-          ')\\b',
-      'gi');
-}
-
-const my_css = GM_getResourceText("IMPORTED_CSS");
-GM_addStyle(my_css);
-
-/**
- * Wraps the replacement text in a span and returns the span as a string.
- *
- * The span will have class 'replacement' and attributes 'data-orig' with
- * the original match and 'data-new' with the replacement text.
- * @param {string} replacement The new text
- * @param {string} match The original text which is being replaced
- * @return {string}
- */
-function replacementHtml(replacement, match, audio_url) {
-  if(audio_url === 'None'){
-  return '<span class="replacement" data-orig="' + match + '" data-new="' +
-      escaped(replacement) + '">' + escaped(replacement) + '</span>';
-  }};
-
-/**
- * Replaces all occurrences that match 'from' in main's innerHTML with a
- * span whose text is 'to'.
- *
- * @param {{innerHTML: string}} main
- * @param {RegExp} from
- * @param {string} to
- */
-function replaceTextOnPage(main, from, to, audio_url) {
-  main.innerHTML = main.innerHTML.replace(from, (match) => {
-    if (match.startsWith('<')) {
-      // Skip matches occurring inside incomplete html tags. This avoids
-      // e.g. replacing within the href for a work tag.
-      return match;
-    }
-    return replacementHtml(to, match, audio_url);
-  });
-}
-
-/**
- * Checks whether 'fandom' (ignoring case) is a substring of any of the
- * fandom tags.
- *
- * @param {string} fandom
- * @param {Element[]} fandomTags
- * @returns {boolean}
- */
-function hasFandom(fandom, fandomTags) {
-  const fandomRegex = new RegExp(fandom, 'i');
-  for (let i = 0; i < fandomTags.length; i++) {
-    if (fandomTags[i].innerHTML.match(fandomRegex) !== null) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * Replaces pinyin for all text in element, using the fandoms in the
- * element's work tags to decide which rules to use.
- *
- * @param {HTMLElement} element
- */
-async function doReplacements(element) {
-  // Having a simplified element to pass to 'replaceAll' allows us to
-  // avoid re-rendering the element every time its inner html gets
-  // updated.
-  const simplifiedElement = {innerHTML: element.innerHTML};
-
-  // Anything with a 'tag' class that's a descendant of something with a
-  // 'fandom' or 'fandoms' class.
-  const workFandoms =
-      Array.from(element.querySelectorAll('.fandoms .tag,.fandom .tag'));
-   if (hasFandom('Word of Honor|Faraway Wanderers|Qi Ye', workFandoms)) {
-     replaceAll(await getReplacements('word_of_honor'), simplifiedElement);
-   }
-  if (hasFandom('Untamed|Módào', workFandoms)) {
-    replaceAll(await getReplacements('mdzs'), simplifiedElement);
-  }
-   if (hasFandom('Guardian', workFandoms)) {
-     replaceAll(await getReplacements('guardian'), simplifiedElement);
-   }
-   if (hasFandom('Nirvana in Fire', workFandoms)) {
-     replaceAll(await getReplacements('nirvana_in_fire'), simplifiedElement);
-   }
-   if (hasFandom('King\'s Avatar|Quánzhí Gāoshǒu', workFandoms)) {
-     replaceAll(await getReplacements('kings_avatar'), simplifiedElement);
-   }
-   if (hasFandom(
-           'TGCF|Tiān Guān Cì Fú|Heaven Official\'s Blessing', workFandoms)) {
-     replaceAll(await getReplacements('tgcf'), simplifiedElement);
-   }
-  if (hasFandom(
-           'SVSSS|Scum Villain|Scumbag System', workFandoms)) {
-     replaceAll(await getReplacements('svsss'), simplifiedElement);
-   }
-  if (hasFandom(
-           'JWQS|Clear and Muddy Loss of Love|Jing Wei Qing Shang', workFandoms)) {
-     replaceAll(await getReplacements('jwqs'), simplifiedElement);
-   }
-  if (hasFandom(
-           '2ha|erha|Husky and His White Cat Shizun', workFandoms)) {
-     replaceAll(await getReplacements('erha'), simplifiedElement);
-   }
-   replaceAll(await getReplacements('generic'), simplifiedElement);
-
-  // Return now if it turns out we didn't make any changes.
-  if (simplifiedElement.innerHTML === element.innerHTML) {
-    console.log('No matching fandoms, or no text found that needed replacing.');
-    return;
-  }
-
-  // Actually replace element's innerHTML.
-  element.innerHTML = simplifiedElement.innerHTML;
-}
-
-/**
- * Gets the replacement string for this fandom from its <fandom>.txt file.
- * @param {string} fandom
- */
-async function getReplacements(fandom) {
-  return GM.getResourceUrl(fandom)
-      .then(url => fetch(url))
-      .then(resp => resp.text())
-      .catch(function(error) {
-        console.log('Request failed', error);
-        return null;
-      });
-}
-
-/**
- * Turns a long replacements string into a list of match objects, where:
- *  - match.words is an array of strings that form the individual words to
- * match
- *  - match.replacement is the text to replace that sequence with
- *
- * @param {string} replacements
- * @returns {{words:string[],replacement:string, audio_url:string}[]}
- */
-function splitReplacements(replacements) {
-  return replacements.split('\n')
-      .map(function(line) {
-        return line.trim();
-      })
-      .filter(function(line) {
-        return line.length > 0 && !line.startsWith('#');
-      })
-      .map(function(line) {
-        const match = line.split('|');
-        if(match.length === 3){
-        return {
-          words: match[0].split(' ').filter(match => match.length > 0),
-          replacement: match[1].trim(),
-          audio_url: 'None'
-        };} else{
-          return {
-          words: match[0].split(' ').filter(match => match.length > 0),
-          replacement: match[1].trim(),
-          audio_url: 'None'
-        };
-        }
-      });
-}
-
-/**
- * Replaces all matches in element.innerHTML with their replacements, as
- * encoded in the rules string.
- *
- * @param {string} allReplacementsString
- * @param {{innerHTML: string}} element
- */
-function replaceAll(allReplacementsString, element) {
-  // Avoid updating element.innerHTML until the very end.
-  const simplifiedElement = {innerHTML: element.innerHTML};
-  const replacements = splitReplacements(allReplacementsString);
-  replacements.forEach(function(rule) {
-    replaceTextOnPage(
-        simplifiedElement, wordsMatchRegex(rule.words), rule.replacement, rule.audio_url);
-  });
-  element.innerHTML = simplifiedElement.innerHTML;
-}
+  await doToneMarksReplacement(/*includeAudio=*/ false);
 })();

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,16 +1,17 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.1.0.3
+// @version      4.1.0.4
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7
 // @match        https://archiveofourown.org/*
-// @updateURL    https://github.com/irrationalpie/AO3-Tone-Marks/raw/refactor/Tone_Marks_withAudio.pub.user.js
-// @downloadURL  https://github.com/irrationalpie/AO3-Tone-Marks/raw/refactor/Tone_Marks_withAudio.pub.user.js
+// @updateURL    https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/Tone_Marks_withAudio.pub.user.js
+// @downloadURL  https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/Tone_Marks_withAudio.pub.user.js
 //
 // @require      replace.js
 // @require      check-fandoms.js
+// @require      mark-tones.js
 // Generic and per-fandom replacement rules:
 // @resource     generic https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/generic.txt
 // @resource     guardian https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/guardian.txt
@@ -27,9 +28,6 @@
 // clang-format on
 // @grant unsafeWindow
 // @grant GM.getResourceUrl
-// @grant GM_xmlhttpRequest
-// @connect raw.githubusercontent.com
-// @connect github.com
 // @grant GM_getResourceText
 // @grant GM_addStyle
 // ==/UserScript==
@@ -37,88 +35,8 @@
 (function() {
 'use strict';
 
-async function doTheThing() {
-  // Url of the ao3 page.
-  const url = unsafeWindow.location.href;
-  // Document structure of the ao3 page.
-  const document = unsafeWindow.document;
-
-  // Check whether this page is an ao3 work.
-  const works_regex = /https:\/\/archiveofourown\.org(\/.*)?\/works\/[0-9]+.*/;
-  // Check whether it's an editing page.
-  const edit_page_regex = /\/works\/[0-9]+\/edit/;
-
-  if (url.match(works_regex) !== null) {
-    if (url.match(edit_page_regex) === null && !url.includes('works/new')) {
-      console.log('On a works page, potentially making pinyin replacements...')
-          // Don't make replacements on the new work/edit work (tag) page,
-          // that sounds confusing.
-          await doReplacements(document.getElementById('main'));
-    }
-  } else {
-    console.log(
-        'Not on a works page; going to try to do pinyin replacement per blurb...')
-    // Get all the work/series blurbs
-    const blurbs = Array.from(document.querySelectorAll('.blurb'));
-    for (let i = 0; i < blurbs.length; i++) {
-      await doReplacements(blurbs[i]);
-    }
-  }
-
-  // Clean up re-replacements.
-  const replacements = Array.from(document.querySelectorAll('.replacement'));
-  replacements.forEach(function(span) {
-    span.innerHTML = span.dataset.new;
-  });
-}
-doTheThing();
-
-GM_xmlhttpRequest({
-  method: 'GET',
-  // from other domain than the @match one (.org / .com):
-  url:
-      'https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/playaudio.min.js',
-  onload: (ev) => {
-    let e = document.createElement('script');
-    e.innerText = ev.responseText;
-    document.head.appendChild(e);
-  }
-});
+doToneMarksReplacement(/*withAudio=*/ true);
 
 const my_css = GM_getResourceText('IMPORTED_CSS');
 GM_addStyle(my_css);
-
-/**
- * Replaces pinyin for all text in element, using the fandoms in the
- * element's work tags to decide which rules to use.
- *
- * @param {HTMLElement} element
- */
-async function doReplacements(element) {
-  const rules = await getReplacementRules(getFandomTags(element));
-
-  let innerHTMLSnapshot;
-  let simplifiedElement;
-  do {
-    // Having a simplified element to pass to 'replaceAll' allows us to
-    // avoid re-rendering the element every time its inner html gets
-    // updated.
-    // Taking a snapshot of the current innerhtml allows us to check whether
-    // other scripts have altered the DOM while we were doing our replacing, and
-    // try again so as not to erase those effects.
-    innerHTMLSnapshot = element.innerHTML;
-    simplifiedElement = {innerHTML: innerHTMLSnapshot};
-
-    replaceAll(rules, simplifiedElement);
-    // Return now if it turns out we didn't make any changes.
-    if (simplifiedElement.innerHTML === element.innerHTML) {
-      console.log(
-          'No matching fandoms, or no text found that needed replacing.');
-      return;
-    }
-  } while (innerHTMLSnapshot !== element.innerHTML);
-
-  // Actually replace element's innerHTML.
-  element.innerHTML = simplifiedElement.innerHTML;
-}
 })();

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.1
+// @version      4.1.0.0
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7
@@ -9,7 +9,7 @@
 // @updateURL    https://github.com/irrationalpie/AO3-Tone-Marks/raw/refactor/Tone_Marks_withAudio.pub.user.js
 // @downloadURL  https://github.com/irrationalpie/AO3-Tone-Marks/raw/refactor/Tone_Marks_withAudio.pub.user.js
 //
-// @require      https://github.com/irrationalpie/AO3-Tone-Marks/raw/refactor/replace.js
+// @require      replace.js
 // Generic and per-fandom replacement rules:
 // @resource     generic https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/generic.txt
 // @resource     guardian https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/guardian.txt

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.1.0.1
+// @version      4.1.0.2
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7
@@ -97,6 +97,7 @@ GM_addStyle(my_css);
 async function doReplacements(element) {
   const rules = await getReplacementRules(getFandomTags(element));
 
+  let innerHTMLSnapshot;
   do {
     // Having a simplified element to pass to 'replaceAll' allows us to
     // avoid re-rendering the element every time its inner html gets
@@ -104,7 +105,7 @@ async function doReplacements(element) {
     // Taking a snapshot of the current innerhtml allows us to check whether
     // other scripts have altered the DOM while we were doing our replacing, and
     // try again so as not to erase those effects.
-    let innerHTMLSnapshot = element.innerHTML;
+    innerHTMLSnapshot = element.innerHTML;
     let simplifiedElement = {innerHTML: innerHTMLSnapshot};
 
     replaceAll(rules, simplifiedElement);

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -2,10 +2,10 @@
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
 // @version      4.0.6
-// @description  Add tone marks on Ao3 works, and add quick audio guide clips were available
+// clang-format off
+// @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7
 // @match        https://archiveofourown.org/*
-// clang-format off
 // @updateURL    https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/Tone_Marks_withAudio.pub.user.js
 // @downloadURL  https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/Tone_Marks_withAudio.pub.user.js
 //
@@ -26,8 +26,9 @@
 // @grant unsafeWindow
 // @grant GM.getResourceUrl
 // @grant GM_xmlhttpRequest
-// @grant      GM_getResourceText
-// @grant      GM_addStyle
+// @connect github.com
+// @grant GM_getResourceText
+// @grant GM_addStyle
 // ==/UserScript==
 
 (function() {
@@ -69,95 +70,20 @@ async function doTheThing() {
 }
 doTheThing();
 
-/**
- * Replaces special html characters.
- * @param {string} str
- * @returns {string}
- */
-function escaped(unsafe) {
-  return (unsafe + '')
-      .replaceAll('&', '&amp;')
-      .replaceAll('<', '&lt;')
-      .replaceAll('>', '&gt;')
-      .replaceAll('"', '&quot;')
-      .replaceAll('\'', '&#039;');
-}
-
-/**
- * Returns a regex to match a sequence of words, allowing an optional
- * dash (-) or space ( ) between each word. The beginning and end of the
- * matching sequence must be at a word boundary.
- *
- * The regex will also match an incomplete html tag preceding the match,
- * which you can check for to avoid replacing within an html tag's
- * attributes.
- *
- * @param {string[]} words
- * @return {RegExp}
- */
-function wordsMatchRegex(words) {
-  return new RegExp(
-      '(<[a-z]+ [^>]*)?\\b(' +
-          words
-              .map(
-                  word =>
-                      escaped(word).replace(/([.?*+^$[\]\\(){}|])/g, '\\$1'))
-              .join('( |-)?') +
-          ')\\b',
-      'gi');
-}
-
 GM_xmlhttpRequest({
-  method : "GET",
+  method: 'GET',
   // from other domain than the @match one (.org / .com):
-  url : "https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/playaudio.min.js",
-  onload : (ev) =>
-  {
+  url:
+      'https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/playaudio.min.js',
+  onload: (ev) => {
     let e = document.createElement('script');
     e.innerText = ev.responseText;
     document.head.appendChild(e);
   }
 });
 
-const my_css = GM_getResourceText("IMPORTED_CSS");
+const my_css = GM_getResourceText('IMPORTED_CSS');
 GM_addStyle(my_css);
-
-/**
- * Wraps the replacement text in a span and returns the span as a string.
- *
- * The span will have class 'replacement' and attributes 'data-orig' with
- * the original match and 'data-new' with the replacement text.
- * @param {string} replacement The new text
- * @param {string} match The original text which is being replaced
- * @return {string}
- */
-function replacementHtml(replacement, match, audio_url) {
-  if(audio_url === 'None'){
-  return '<span class="replacement" data-orig="' + match + '" data-new="' +
-      escaped(replacement) + '">' + escaped(replacement) + '</span>';
-  }else{
-  return '<span onclick="playAudio(\''+ audio_url + '\');" style="cursor: pointer;" class="replacement" data-orig="' + match + '" data-new="' +
-      escaped(replacement) + '">' + escaped(replacement) + '</span><span class="audio-guide" onclick="playAudio(\''+ audio_url + '\');"><i class="material-icons" style="font-size:100%;cursor: pointer;-ms-transform: translateY(-40%);transform: translateY(-40%);">volume_up</i></span>';
-}};
-
-/**
- * Replaces all occurrences that match 'from' in main's innerHTML with a
- * span whose text is 'to'.
- *
- * @param {{innerHTML: string}} main
- * @param {RegExp} from
- * @param {string} to
- */
-function replaceTextOnPage(main, from, to, audio_url) {
-  main.innerHTML = main.innerHTML.replace(from, (match) => {
-    if (match.startsWith('<')) {
-      // Skip matches occurring inside incomplete html tags. This avoids
-      // e.g. replacing within the href for a work tag.
-      return match;
-    }
-    return replacementHtml(to, match, audio_url);
-  });
-}
 
 /**
  * Checks whether 'fandom' (ignoring case) is a substring of any of the
@@ -193,38 +119,37 @@ async function doReplacements(element) {
   // 'fandom' or 'fandoms' class.
   const workFandoms =
       Array.from(element.querySelectorAll('.fandoms .tag,.fandom .tag'));
-   if (hasFandom('Word of Honor|Faraway Wanderers|Qi Ye', workFandoms)) {
-     replaceAll(await getReplacements('word_of_honor'), simplifiedElement);
-   }
+  if (hasFandom('Word of Honor|Faraway Wanderers|Qi Ye', workFandoms)) {
+    replaceAll(await getReplacements('word_of_honor'), simplifiedElement);
+  }
   if (hasFandom('Untamed|Módào', workFandoms)) {
     replaceAll(await getReplacements('mdzs'), simplifiedElement);
   }
-   if (hasFandom('Guardian', workFandoms)) {
-     replaceAll(await getReplacements('guardian'), simplifiedElement);
-   }
-   if (hasFandom('Nirvana in Fire', workFandoms)) {
-     replaceAll(await getReplacements('nirvana_in_fire'), simplifiedElement);
-   }
-   if (hasFandom('King\'s Avatar|Quánzhí Gāoshǒu', workFandoms)) {
-     replaceAll(await getReplacements('kings_avatar'), simplifiedElement);
-   }
-   if (hasFandom(
-           'TGCF|Tiān Guān Cì Fú|Heaven Official\'s Blessing', workFandoms)) {
-     replaceAll(await getReplacements('tgcf'), simplifiedElement);
-   }
+  if (hasFandom('Guardian', workFandoms)) {
+    replaceAll(await getReplacements('guardian'), simplifiedElement);
+  }
+  if (hasFandom('Nirvana in Fire', workFandoms)) {
+    replaceAll(await getReplacements('nirvana_in_fire'), simplifiedElement);
+  }
+  if (hasFandom('King\'s Avatar|Quánzhí Gāoshǒu', workFandoms)) {
+    replaceAll(await getReplacements('kings_avatar'), simplifiedElement);
+  }
   if (hasFandom(
-           'SVSSS|Scum Villain|Scumbag System', workFandoms)) {
-     replaceAll(await getReplacements('svsss'), simplifiedElement);
-   }
+          'TGCF|Tiān Guān Cì Fú|Heaven Official\'s Blessing', workFandoms)) {
+    replaceAll(await getReplacements('tgcf'), simplifiedElement);
+  }
+  if (hasFandom('SVSSS|Scum Villain|Scumbag System', workFandoms)) {
+    replaceAll(await getReplacements('svsss'), simplifiedElement);
+  }
   if (hasFandom(
-           'JWQS|Clear and Muddy Loss of Love|Jing Wei Qing Shang', workFandoms)) {
-     replaceAll(await getReplacements('jwqs'), simplifiedElement);
-   }
-  if (hasFandom(
-           '2ha|erha|Husky and His White Cat Shizun', workFandoms)) {
-     replaceAll(await getReplacements('erha'), simplifiedElement);
-   }
-   replaceAll(await getReplacements('generic'), simplifiedElement);
+          'JWQS|Clear and Muddy Loss of Love|Jing Wei Qing Shang',
+          workFandoms)) {
+    replaceAll(await getReplacements('jwqs'), simplifiedElement);
+  }
+  if (hasFandom('2ha|erha|Husky and His White Cat Shizun', workFandoms)) {
+    replaceAll(await getReplacements('erha'), simplifiedElement);
+  }
+  replaceAll(await getReplacements('generic'), simplifiedElement);
 
   // Return now if it turns out we didn't make any changes.
   if (simplifiedElement.innerHTML === element.innerHTML) {
@@ -248,57 +173,5 @@ async function getReplacements(fandom) {
         console.log('Request failed', error);
         return null;
       });
-}
-
-/**
- * Turns a long replacements string into a list of match objects, where:
- *  - match.words is an array of strings that form the individual words to
- * match
- *  - match.replacement is the text to replace that sequence with
- *
- * @param {string} replacements
- * @returns {{words:string[],replacement:string, audio_url:string}[]}
- */
-function splitReplacements(replacements) {
-  return replacements.split('\n')
-      .map(function(line) {
-        return line.trim();
-      })
-      .filter(function(line) {
-        return line.length > 0 && !line.startsWith('#');
-      })
-      .map(function(line) {
-        const match = line.split('|');
-        if(match.length === 3){
-        return {
-          words: match[0].split(' ').filter(match => match.length > 0),
-          replacement: match[1].trim(),
-          audio_url: match[2].trim()
-        };} else{
-          return {
-          words: match[0].split(' ').filter(match => match.length > 0),
-          replacement: match[1].trim(),
-          audio_url: 'None'
-        };
-        }
-      });
-}
-
-/**
- * Replaces all matches in element.innerHTML with their replacements, as
- * encoded in the rules string.
- *
- * @param {string} allReplacementsString
- * @param {{innerHTML: string}} element
- */
-function replaceAll(allReplacementsString, element) {
-  // Avoid updating element.innerHTML until the very end.
-  const simplifiedElement = {innerHTML: element.innerHTML};
-  const replacements = splitReplacements(allReplacementsString);
-  replacements.forEach(function(rule) {
-    replaceTextOnPage(
-        simplifiedElement, wordsMatchRegex(rule.words), rule.replacement, rule.audio_url);
-  });
-  element.innerHTML = simplifiedElement.innerHTML;
 }
 })();

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.1.0.5
+// @version      4.1.1
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7
@@ -25,17 +25,16 @@
 // @resource     erha https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/erha.txt
 // @resource     IMPORTED_CSS https://fonts.googleapis.com/icon?family=Material+Icons
 // clang-format on
-// @grant unsafeWindow
 // @grant GM.getResourceUrl
 // @grant GM_getResourceText
 // @grant GM_addStyle
 // ==/UserScript==
 
-(function() {
-'use strict';
+(async function() {
+  'use strict';
 
-doToneMarksReplacement(/*withAudio=*/ true);
+  await doToneMarksReplacement(/*includeAudio=*/ true);
 
-const my_css = GM_getResourceText('IMPORTED_CSS');
-GM_addStyle(my_css);
+  const my_css = GM_getResourceText('IMPORTED_CSS');
+  GM_addStyle(my_css);
 })();

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,14 +1,15 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.0.6
+// @version      4.1
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7
 // @match        https://archiveofourown.org/*
-// @updateURL    https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/Tone_Marks_withAudio.pub.user.js
-// @downloadURL  https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/Tone_Marks_withAudio.pub.user.js
+// @updateURL    https://github.com/irrationalpie/AO3-Tone-Marks/raw/refactor/Tone_Marks_withAudio.pub.user.js
+// @downloadURL  https://github.com/irrationalpie/AO3-Tone-Marks/raw/refactor/Tone_Marks_withAudio.pub.user.js
 //
+// @require      https://github.com/irrationalpie/AO3-Tone-Marks/raw/refactor/replace.js
 // Generic and per-fandom replacement rules:
 // @resource     generic https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/generic.txt
 // @resource     guardian https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/guardian.txt
@@ -26,6 +27,7 @@
 // @grant unsafeWindow
 // @grant GM.getResourceUrl
 // @grant GM_xmlhttpRequest
+// @connect raw.githubusercontent.com
 // @connect github.com
 // @grant GM_getResourceText
 // @grant GM_addStyle

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.1.0.2
+// @version      4.1.0.3
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7
@@ -98,6 +98,7 @@ async function doReplacements(element) {
   const rules = await getReplacementRules(getFandomTags(element));
 
   let innerHTMLSnapshot;
+  let simplifiedElement;
   do {
     // Having a simplified element to pass to 'replaceAll' allows us to
     // avoid re-rendering the element every time its inner html gets
@@ -106,7 +107,7 @@ async function doReplacements(element) {
     // other scripts have altered the DOM while we were doing our replacing, and
     // try again so as not to erase those effects.
     innerHTMLSnapshot = element.innerHTML;
-    let simplifiedElement = {innerHTML: innerHTMLSnapshot};
+    simplifiedElement = {innerHTML: innerHTMLSnapshot};
 
     replaceAll(rules, simplifiedElement);
     // Return now if it turns out we didn't make any changes.

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.1.0.4
+// @version      4.1.0.5
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7
@@ -23,7 +23,6 @@
 // @resource     svsss https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/svsss.txt
 // @resource     jwqs https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/jwqs.txt
 // @resource     erha https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/erha.txt
-// @resource     audioplay https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/playaudio.min.js
 // @resource     IMPORTED_CSS https://fonts.googleapis.com/icon?family=Material+Icons
 // clang-format on
 // @grant unsafeWindow

--- a/check-fandoms.js
+++ b/check-fandoms.js
@@ -1,0 +1,126 @@
+/**
+ * Checks whether 'fandomNames' (ignoring case) is a substring of any of the
+ * fandom tags, and if so appends the relevant rules.
+ *
+ * @param {string} fandomNames
+ * @param {string} fandomId
+ * @param {Element[]} fandomTags
+ * @param {{asString:string}} rules
+ */
+async function updateRulesForFandom(fandomNames, fandomId, fandomTags, rules) {
+  const fandomRegex = new RegExp(fandomNames, 'i');
+  for (let i = 0; i < fandomTags.length; i++) {
+    if (fandomTags[i].innerHTML.match(fandomRegex) !== null) {
+      rules.asString += await getReplacements(fandomId) + '\n';
+      return;
+    }
+  }
+}
+
+/**
+ * Get an array of fandom tags associated with a work or blurb element.
+ * @param {HTMLElement} element
+ * @returns {HTMLElement[]}
+ */
+function getFandomTags(element) {
+  return Array.from(element.querySelectorAll('.fandoms .tag,.fandom .tag'));
+}
+
+/**
+ * Gets the replacement rules for an element, based on its fandom tags.
+ *
+ * @param {HTMLElement[]} workFandoms The fandom tags for this work.
+ *
+ * @returns {{words:string[],replacement:string, audio_url:string}[]} A list of
+ *     replacement rules. Each rule consists of a list of word(s) to replace,
+ *     what they should be replaced with, and potentially an audio_url with
+ *     pronunciation.
+ */
+async function getReplacementRules(workFandoms) {
+  // If there's no fandoms, there can be no replacement rules.
+  if (workFandoms.length === 0) {
+    console.log('Didn\'t detect any fandoms--no replacements possible.')
+    return [];
+  }
+
+  // Yay hacky mutable string.
+  const rules = {asString: ''}
+
+  // To add new fandom, copy commented line and update 'fandom_names' and 'id':
+  // await updateRulesForFandom('fandom_names', 'id', workFandoms, rules);
+  await updateRulesForFandom(
+      'Word of Honor|Faraway Wanderers|Qi Ye', 'word_of_honor', workFandoms,
+      rules);
+  await updateRulesForFandom('Untamed|Módào', 'mdzs', workFandoms, rules);
+  await updateRulesForFandom('Guardian', 'guardian', workFandoms, rules);
+  await updateRulesForFandom(
+      'Nirvana in Fire', 'nirvana_in_fire', workFandoms, rules);
+  await updateRulesForFandom(
+      'King\'s Avatar|Quánzhí Gāoshǒu', 'kings_avatar', workFandoms, rules);
+  await updateRulesForFandom(
+      'TGCF|Tiān Guān Cì Fú|Heaven Official\'s Blessing', 'tgcf', workFandoms,
+      rules);
+  await updateRulesForFandom(
+      'SVSSS|Scum Villain|Scumbag System', 'svsss', workFandoms, rules);
+  await updateRulesForFandom(
+      'JWQS|Clear and Muddy Loss of Love|Jing Wei Qing Shang', 'jwqs',
+      workFandoms, rules);
+  await updateRulesForFandom(
+      '2ha|erha|Husky and His White Cat Shizun', 'erha', workFandoms, rules);
+
+  // Add non-fandom-specific rules at the end.
+  await updateRulesForFandom('', 'generic', workFandoms, rules);
+
+  return splitReplacements(rules.asString);
+}
+
+/**
+ * Loads the replacement string for this fandom from its <fandom>.txt file.
+ * @param {string} fandom
+ */
+async function getReplacements(fandom) {
+  return GM.getResourceUrl(fandom)
+      .then(url => fetch(url))
+      .then(resp => resp.text())
+      .catch(function(error) {
+        console.log('Request failed', error);
+        return null;
+      });
+}
+
+/**
+ * Turns a long replacements string into a list of match objects, where:
+ *  - match.words is an array of strings that form the individual words to
+ * match
+ *  - match.replacement is the text to replace that sequence with
+ *  - match.audio_url is an optional url pointing to audio that pronounces this
+ * text.
+ *
+ * @param {string} replacements
+ * @returns {{words:string[],replacement:string, audio_url:string}[]}
+ */
+function splitReplacements(replacements) {
+  return replacements.split('\n')
+      .map(function(line) {
+        return line.trim();
+      })
+      .filter(function(line) {
+        return line.length > 0 && !line.startsWith('#');
+      })
+      .map(function(line) {
+        const match = line.split('|');
+        if (match.length === 3) {
+          return {
+            words: match[0].split(' ').filter(match => match.length > 0),
+            replacement: match[1].trim(),
+            audio_url: match[2].trim()
+          };
+        } else {
+          return {
+            words: match[0].split(' ').filter(match => match.length > 0),
+            replacement: match[1].trim(),
+            audio_url: 'None'
+          };
+        }
+      });
+}

--- a/mark-tones.js
+++ b/mark-tones.js
@@ -1,0 +1,79 @@
+/**
+ * Place tone marks in work or work blurbs on the current page.
+ * @param {boolean} includeAudio whether to include audio pronunciation
+ */
+async function doToneMarksReplacement(includeAudio) {
+  // Url of the ao3 page.
+  const url = unsafeWindow.location.href;
+  // Document structure of the ao3 page.
+  const document = unsafeWindow.document;
+
+  // Check whether this page is an ao3 work.
+  const works_regex = /https:\/\/archiveofourown\.org(\/.*)?\/works\/[0-9]+.*/;
+  // Check whether it's an editing page.
+  const edit_page_regex = /\/works\/[0-9]+\/edit/;
+
+  if (url.match(works_regex) !== null) {
+    if (url.match(edit_page_regex) === null && !url.includes('works/new')) {
+      console.log('On a works page, potentially making pinyin replacements...')
+          // Don't make replacements on the new work/edit work (tag) page,
+          // that sounds confusing.
+          await doReplacements(document.getElementById('main'));
+    }
+  } else {
+    console.log(
+        'Not on a works page; going to try to do pinyin replacement per blurb...')
+    // Get all the work/series blurbs
+    const blurbs = Array.from(document.querySelectorAll('.blurb'));
+    for (let i = 0; i < blurbs.length; i++) {
+      await doReplacements(blurbs[i]);
+    }
+  }
+
+  // Clean up re-replacements and add audio functionality.
+  const replacements = Array.from(document.querySelectorAll('.replacement'));
+  replacements.forEach(span => {
+    span.innerHTML = span.dataset.new;
+    if (includeAudio && span.dataset.url !== 'None') {
+      span.innerHTML +=
+          '<span class="audio-guide"><i class="material-icons" style="font-size:100%;cursor: pointer;-ms-transform: translateY(-40%);transform: translateY(-40%);">volume_up</i></span>'
+      span.onclick = () => {
+        new Audio(span.dataset.url).play();
+      };
+    }
+  });
+}
+
+/**
+ * Replaces pinyin for all text in element, using the fandoms in the
+ * element's work tags to decide which rules to use.
+ *
+ * @param {HTMLElement} element
+ */
+async function doReplacements(element) {
+  const rules = await getReplacementRules(getFandomTags(element));
+
+  let innerHTMLSnapshot;
+  let simplifiedElement;
+  do {
+    // Having a simplified element to pass to 'replaceAll' allows us to
+    // avoid re-rendering the element every time its inner html gets
+    // updated.
+    // Taking a snapshot of the current innerhtml allows us to check whether
+    // other scripts have altered the DOM while we were doing our replacing, and
+    // try again so as not to erase those effects.
+    innerHTMLSnapshot = element.innerHTML;
+    simplifiedElement = {innerHTML: innerHTMLSnapshot};
+
+    replaceAll(rules, simplifiedElement);
+    // Return now if it turns out we didn't make any changes.
+    if (simplifiedElement.innerHTML === element.innerHTML) {
+      console.log(
+          'No matching fandoms, or no text found that needed replacing.');
+      return;
+    }
+  } while (innerHTMLSnapshot !== element.innerHTML);
+
+  // Actually replace element's innerHTML.
+  element.innerHTML = simplifiedElement.innerHTML;
+}

--- a/mark-tones.js
+++ b/mark-tones.js
@@ -4,9 +4,7 @@
  */
 async function doToneMarksReplacement(includeAudio) {
   // Url of the ao3 page.
-  const url = unsafeWindow.location.href;
-  // Document structure of the ao3 page.
-  const document = unsafeWindow.document;
+  const url = location.href;
 
   // Check whether this page is an ao3 work.
   const works_regex = /https:\/\/archiveofourown\.org(\/.*)?\/works\/[0-9]+.*/;
@@ -37,6 +35,7 @@ async function doToneMarksReplacement(includeAudio) {
     if (includeAudio && span.dataset.url !== 'None') {
       span.innerHTML +=
           '<span class="audio-guide"><i class="material-icons" style="font-size:100%;cursor: pointer;-ms-transform: translateY(-40%);transform: translateY(-40%);">volume_up</i></span>'
+      span.style.cursor = 'pointer';
       span.onclick = () => {
         new Audio(span.dataset.url).play();
       };

--- a/replace.js
+++ b/replace.js
@@ -46,17 +46,9 @@ function wordsMatchRegex(words) {
  * @return {string}
  */
 function replacementHtml(replacement, match, audio_url) {
-  if (audio_url === 'None') {
-    return '<span class="replacement" data-orig="' + match + '" data-new="' +
-        escaped(replacement) + '">' + escaped(replacement) + '</span>';
-  } else {
-    return '<span onclick="playAudio(\'' + audio_url +
-        '\');" style="cursor: pointer;" class="replacement" data-orig="' +
-        match + '" data-new="' + escaped(replacement) + '">' +
-        escaped(replacement) +
-        '</span><span class="audio-guide" onclick="playAudio(\'' + audio_url +
-        '\');"><i class="material-icons" style="font-size:100%;cursor: pointer;-ms-transform: translateY(-40%);transform: translateY(-40%);">volume_up</i></span>';
-  }
+  return '<span class="replacement" data-orig="' + match + '" data-new="' +
+      escaped(replacement) + '" data-url="' + audio_url + '">' +
+      escaped(replacement) + '</span>';
 }
 
 /**

--- a/replace.js
+++ b/replace.js
@@ -1,0 +1,152 @@
+/**
+ * Replaces special html characters.
+ * @param {string} str
+ * @returns {string}
+ */
+function escaped(unsafe) {
+  return (unsafe + '')
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll('\'', '&#039;');
+}
+
+/**
+ * Returns a regex to match a sequence of words, allowing an optional
+ * dash (-) or space ( ) between each word. The beginning and end of the
+ * matching sequence must be at a word boundary.
+ *
+ * The regex will also match an incomplete html tag preceding the match,
+ * which you can check for to avoid replacing within an html tag's
+ * attributes.
+ *
+ * @param {string[]} words
+ * @return {RegExp}
+ */
+function wordsMatchRegex(words) {
+  return new RegExp(
+      '(<[a-z]+ [^>]*)?\\b(' +
+          words
+              .map(
+                  word =>
+                      escaped(word).replace(/([.?*+^$[\]\\(){}|])/g, '\\$1'))
+              .join('( |-)?') +
+          ')\\b',
+      'gi');
+}
+
+/**
+ * Wraps the replacement text in a span and returns the span as a string.
+ *
+ * The span will have class 'replacement' and attributes 'data-orig' with
+ * the original match and 'data-new' with the replacement text.
+ * @param {string} replacement The new text
+ * @param {string} match The original text which is being replaced
+ * @return {string}
+ */
+function replacementHtml(replacement, match, audio_url) {
+  if (audio_url === 'None') {
+    return '<span class="replacement" data-orig="' + match + '" data-new="' +
+        escaped(replacement) + '">' + escaped(replacement) + '</span>';
+  } else {
+    return '<span onclick="playAudio(\'' + audio_url +
+        '\');" style="cursor: pointer;" class="replacement" data-orig="' +
+        match + '" data-new="' + escaped(replacement) + '">' +
+        escaped(replacement) +
+        '</span><span class="audio-guide" onclick="playAudio(\'' + audio_url +
+        '\');"><i class="material-icons" style="font-size:100%;cursor: pointer;-ms-transform: translateY(-40%);transform: translateY(-40%);">volume_up</i></span>';
+  }
+}
+
+/**
+ * Replaces all occurrences that match 'from' in main's innerHTML with a
+ * span whose text is 'to'.
+ *
+ * @param {{innerHTML: string}} main
+ * @param {RegExp} from
+ * @param {string} to
+ */
+function replaceTextOnPage(main, from, to, audio_url) {
+  main.innerHTML = main.innerHTML.replace(from, (match) => {
+    if (match.startsWith('<')) {
+      // Skip matches occurring inside incomplete html tags. This avoids
+      // e.g. replacing within the href for a work tag.
+      return match;
+    }
+    return replacementHtml(to, match, audio_url);
+  });
+}
+
+/**
+ * Turns a long replacements string into a list of match objects, where:
+ *  - match.words is an array of strings that form the individual words to
+ * match
+ *  - match.replacement is the text to replace that sequence with
+ *
+ * @param {string} replacements
+ * @returns {{words:string[],replacement:string, audio_url:string}[]}
+ */
+function splitReplacements(replacements) {
+  return replacements.split('\n')
+      .map(function(line) {
+        return line.trim();
+      })
+      .filter(function(line) {
+        return line.length > 0 && !line.startsWith('#');
+      })
+      .map(function(line) {
+        const match = line.split('|');
+        if (match.length === 3) {
+          return {
+            words: match[0].split(' ').filter(match => match.length > 0),
+            replacement: match[1].trim(),
+            audio_url: match[2].trim()
+          };
+        } else {
+          return {
+            words: match[0].split(' ').filter(match => match.length > 0),
+            replacement: match[1].trim(),
+            audio_url: 'None'
+          };
+        }
+      });
+}
+
+/**
+ * Replaces all matches in element.innerHTML with their replacements, as
+ * encoded in the rules string.
+ *
+ * @param {string} allReplacementsString
+ * @param {{innerHTML: string}} element
+ */
+function replaceAll(allReplacementsString, element) {
+  // Avoid updating element.innerHTML until the very end.
+  const simplifiedElement = {innerHTML: element.innerHTML};
+  const replacements = splitReplacements(allReplacementsString);
+  replacements.forEach(function(rule) {
+    replaceTextOnPage(
+        simplifiedElement, wordsMatchRegex(rule.words), rule.replacement,
+        rule.audio_url);
+  });
+  element.innerHTML = simplifiedElement.innerHTML;
+}
+
+/**
+ * Replaces all matches in element.innerHTML with their replacements, as
+ * encoded in the rules string.
+ *
+ * @param {string} allReplacementsString
+ * @param {{innerHTML: string}} element
+ */
+function replaceAll(allReplacementsString, element) {
+  // Avoid updating element.innerHTML until the very end.
+  const simplifiedElement = {innerHTML: element.innerHTML};
+  const replacements = splitReplacements(allReplacementsString);
+  replacements.forEach(function(rule) {
+    replaceTextOnPage(
+        simplifiedElement, wordsMatchRegex(rule.words), rule.replacement,
+        rule.audio_url);
+  });
+  element.innerHTML = simplifiedElement.innerHTML;
+}

--- a/replace.js
+++ b/replace.js
@@ -79,70 +79,15 @@ function replaceTextOnPage(main, from, to, audio_url) {
 }
 
 /**
- * Turns a long replacements string into a list of match objects, where:
- *  - match.words is an array of strings that form the individual words to
- * match
- *  - match.replacement is the text to replace that sequence with
- *
- * @param {string} replacements
- * @returns {{words:string[],replacement:string, audio_url:string}[]}
- */
-function splitReplacements(replacements) {
-  return replacements.split('\n')
-      .map(function(line) {
-        return line.trim();
-      })
-      .filter(function(line) {
-        return line.length > 0 && !line.startsWith('#');
-      })
-      .map(function(line) {
-        const match = line.split('|');
-        if (match.length === 3) {
-          return {
-            words: match[0].split(' ').filter(match => match.length > 0),
-            replacement: match[1].trim(),
-            audio_url: match[2].trim()
-          };
-        } else {
-          return {
-            words: match[0].split(' ').filter(match => match.length > 0),
-            replacement: match[1].trim(),
-            audio_url: 'None'
-          };
-        }
-      });
-}
-
-/**
  * Replaces all matches in element.innerHTML with their replacements, as
  * encoded in the rules string.
  *
- * @param {string} allReplacementsString
+ * @param {{words:string[],replacement:string, audio_url:string}[]} replacements
  * @param {{innerHTML: string}} element
  */
-function replaceAll(allReplacementsString, element) {
+function replaceAll(replacements, element) {
   // Avoid updating element.innerHTML until the very end.
   const simplifiedElement = {innerHTML: element.innerHTML};
-  const replacements = splitReplacements(allReplacementsString);
-  replacements.forEach(function(rule) {
-    replaceTextOnPage(
-        simplifiedElement, wordsMatchRegex(rule.words), rule.replacement,
-        rule.audio_url);
-  });
-  element.innerHTML = simplifiedElement.innerHTML;
-}
-
-/**
- * Replaces all matches in element.innerHTML with their replacements, as
- * encoded in the rules string.
- *
- * @param {string} allReplacementsString
- * @param {{innerHTML: string}} element
- */
-function replaceAll(allReplacementsString, element) {
-  // Avoid updating element.innerHTML until the very end.
-  const simplifiedElement = {innerHTML: element.innerHTML};
-  const replacements = splitReplacements(allReplacementsString);
   replacements.forEach(function(rule) {
     replaceTextOnPage(
         simplifiedElement, wordsMatchRegex(rule.words), rule.replacement,


### PR DESCRIPTION
In order to keep the tone marks scripts, with and without audio, from drifting too far, I thought it might be useful to refactor their shared functionality.

The proposed new structure has `Tone_Marks.pub.user.js` and `Tone_Marks_withAudio.pub.user.js` delegate almost entirely to `mark-tones.js`, which itself delegates to `check-fandoms.js` for figuring out which fandom replacement rules apply, and `replace.js` for the actual replacement. Post-processing in `mark-tones.js`, after the replacement step, adds the pronunciation audio, if available and requested, based on a boolean.

This isn't a pure refactor--I made a couple functionality changes while I was at it:

- Replacement rules for all applicable fandoms, plus the generic replacements, are combined into a single list before being applied, instead of being applied in per-fandom chunks. This will help with performance for a fix idea I have for the known issue where the Download, Chapter Index, and Bookmark button do not work while either script version is running, but shouldn't have any real effect now.
- The script will no longer make replacements to works or blurbs without fandom tags. As far as I'm aware, this basically means the chapter index (/navigate) and paged kudos pages (/kudos) for a work. These would only have made generic replacements anyway, and it was conflicting with another script I wanted to run, so I decided it wasn't worth it.
- In the audio version of the script, the audio symbol span is now nested within the replacement span, rather than coming right after it.
- In addition to `data-new` and `data-orig` attributes, the replacement span now also has a `data-url` attribute containing either an audio url or the text 'None'.
- Some userscript permissions that didn't seem to be necessary were removed
- I now make an attempt to snapshot the innerHTML of the work page/blurb when we start processing it, and compare it to the current state of the DOM when we finish processing it. If the innerHTML has changed in between, we now reprocess it so as not to remove changes another script may have made. I'm not totally sure this works because the conflict I was seeing with another script earlier (["AO3 all-chapter word counts" from here](https://github.com/irrationalpie7/fandom-scripts/tree/main/tampermonkey)) was on the navigate page, and we no longer make replacements there.

Note: after this change, `playaudio.min.js` is no longer used, but given that it's loaded remotely we might need to keep it around for a bit since old versions of the audio script presumably will keep trying to read it.

Note 2: I tested that this user script works on both Firefox (violentmonkey) and Chrome (tampermonkey). I initially tried making it work with greasemonkey on Firefox, but was unable to get it to install correctly. Since I also had trouble installing the version currently in the repo, I decided it was probably an issue with greasemonkey, and that the workaround (violentmonkey, an open-source alternative to tampermonkey) meant it was good enough.

For test installation, here are the [no-audio](https://github.com/irrationalpie7/AO3-Tone-Marks/raw/refactor/Tone_Marks.pub.user.js) and [with-audio](https://github.com/irrationalpie7/AO3-Tone-Marks/raw/refactor/Tone_Marks_withAudio.pub.user.js) versions of the script. 


