### PR TITLE
Recursively replace pinyin to avoid conflicting with ao3 or other scripts (fixes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@ Audio guide support is currently in progress. Not every word has audio at this p
 If you would like to help contribute tone marks for fandoms that are not yet supported, you can do that in the google sheet <a href="https://docs.google.com/spreadsheets/d/1cfmiVdMwXTU4EgG45kow9MKWMOSwmiShX5iO50bmwmU/edit?usp=sharing">here</a>. If you want to make changes to existing replacement rules, you can either change them in the spreadsheet and then mark the row red, or you can change it in the spreadsheet and submit a pull request where it is also changed in the corresponding fandoms file, noting what it is you changed.
 
 ## Issues
-If you spot an issue like missing or wrong tone marks, please let me know either by submitting an issue here or reaching out to me on twitter/tumblr @cathalinaheart or via email cathalinaheart {at} gmail.com.
-
-###### Currently Known
-- The Download, Chapter Index and Bookmark button do not work while the script is running
+If you spot an issue like missing or wrong tone marks, please let me know either by [submitting an issue here](https://github.com/Cathalinaheart/AO3-Tone-Marks/issues) or reaching out to me on twitter/tumblr @cathalinaheart or via email cathalinaheart {at} gmail.com.
 
 ## Other
 ###### Underline Replacements

--- a/Tone_Marks.pub.user.js
+++ b/Tone_Marks.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks
 // @namespace    http://tampermonkey.net/
-// @version      4.1.2.2
+// @version      4.2
 // clang-format off
 // @description  Add tone marks on Ao3 works
 // @author       Cathalinaheart, irrationalpie7

--- a/Tone_Marks.pub.user.js
+++ b/Tone_Marks.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks
 // @namespace    http://tampermonkey.net/
-// @version      4.1.1
+// @version      4.1.2.1
 // clang-format off
 // @description  Add tone marks on Ao3 works
 // @author       Cathalinaheart, irrationalpie7

--- a/Tone_Marks.pub.user.js
+++ b/Tone_Marks.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks
 // @namespace    http://tampermonkey.net/
-// @version      4.1.2.1
+// @version      4.1.2.2
 // clang-format off
 // @description  Add tone marks on Ao3 works
 // @author       Cathalinaheart, irrationalpie7

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.1.1
+// @version      4.2
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7

--- a/mark-tones.js
+++ b/mark-tones.js
@@ -51,28 +51,5 @@ async function doToneMarksReplacement(includeAudio) {
  */
 async function doReplacements(element) {
   const rules = await getReplacementRules(getFandomTags(element));
-
-  let innerHTMLSnapshot;
-  let simplifiedElement;
-  do {
-    // Having a simplified element to pass to 'replaceAll' allows us to
-    // avoid re-rendering the element every time its inner html gets
-    // updated.
-    // Taking a snapshot of the current innerhtml allows us to check whether
-    // other scripts have altered the DOM while we were doing our replacing, and
-    // try again so as not to erase those effects.
-    innerHTMLSnapshot = element.innerHTML;
-    simplifiedElement = {innerHTML: innerHTMLSnapshot};
-
-    replaceAll(rules, simplifiedElement);
-    // Return now if it turns out we didn't make any changes.
-    if (simplifiedElement.innerHTML === element.innerHTML) {
-      console.log(
-          'No matching fandoms, or no text found that needed replacing.');
-      return;
-    }
-  } while (innerHTMLSnapshot !== element.innerHTML);
-
-  // Actually replace element's innerHTML.
-  element.innerHTML = simplifiedElement.innerHTML;
+  replaceAll(rules, element);
 }

--- a/replace.js
+++ b/replace.js
@@ -92,25 +92,18 @@ function replaceTextNode(textNode, newInnerHtml) {
  * @param {HTMLElement} element
  */
 function recursiveReplace(replacements, element) {
-  // Track text nodes that will be replaced with a mix of text nodes and
-  // elements.
-  const textReplacements = [];
-  for (const child of element.childNodes) {
+  // Snapshot the children to iterate over them without having to worry about
+  // whether the list changes as we go along.
+  const currentChildren = Array.from(element.childNodes);
+  for (const child of currentChildren) {
     if (child.nodeType === Node.TEXT_NODE) {
       const newInnerHtml = replaceText(replacements, child.textContent)
       if (newInnerHtml !== child.textContent) {
-        // If we made the replacement here, we'd alter the number of
-        // children and potentially reprocess some of them, so we put
-        // that off until the end.
-        textReplacements.push({child, newInnerHtml});
+        replaceTextNode(child, newInnerHtml);
       }
     } else {
       recursiveReplace(replacements, child);
     }
-  }
-  // Make the replacements.
-  for (const textReplacement of textReplacements) {
-    replaceTextNode(textReplacement.child, textReplacement.newInnerHtml);
   }
 }
 

--- a/replace.js
+++ b/replace.js
@@ -71,19 +71,75 @@ function replaceTextOnPage(main, from, to, audio_url) {
 }
 
 /**
+ * Alters the parent of textNode to replace textNode with whatever html is in
+ * newInnerHtml. Siblings of textNode remain unchanged.
+ *
+ * @param {Text} textNode
+ * @param {string} newInnerHtml
+ */
+function replaceTextNode(textNode, newInnerHtml) {
+  textNode.parentNode.replaceChild(
+      textNode.ownerDocument.createRange().createContextualFragment(
+          newInnerHtml),
+      textNode);
+}
+
+/**
  * Replaces all matches in element.innerHTML with their replacements, as
  * encoded in the rules string.
  *
  * @param {{words:string[],replacement:string, audio_url:string}[]} replacements
- * @param {{innerHTML: string}} element
+ * @param {HTMLElement} element
  */
-function replaceAll(replacements, element) {
-  // Avoid updating element.innerHTML until the very end.
-  const simplifiedElement = {innerHTML: element.innerHTML};
-  replacements.forEach(function(rule) {
+function recursiveReplace(replacements, element) {
+  // Track text nodes that will be replaced with a mix of text nodes and
+  // elements.
+  const textReplacements = [];
+  for (const child of element.childNodes) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      const newInnerHtml = replaceText(replacements, child.textContent)
+      if (newInnerHtml !== child.textContent) {
+        // If we made the replacement here, we'd alter the number of
+        // children and potentially reprocess some of them, so we put
+        // that off until the end.
+        textReplacements.push({child, newInnerHtml});
+      }
+    } else {
+      recursiveReplace(replacements, child);
+    }
+  }
+  // Make the replacements.
+  for (const textReplacement of textReplacements) {
+    replaceTextNode(textReplacement.child, textReplacement.newInnerHtml);
+  }
+}
+
+/**
+ * Replace text (which is not html) according to the rules in the replacements
+ * list, resulting in text with html markup.
+ *
+ * @param {{words:string[],replacement:string, audio_url:string}[]} replacements
+ * @param {string} text
+ * @returns {string} replacement text, which may have html formatting
+ */
+function replaceText(replacements, text) {
+  // pretend text is part of an element
+  const simplifiedElement = {innerHTML: text};
+  replacements.forEach(rule => {
     replaceTextOnPage(
         simplifiedElement, wordsMatchRegex(rule.words), rule.replacement,
         rule.audio_url);
   });
-  element.innerHTML = simplifiedElement.innerHTML;
+  return simplifiedElement.innerHTML;
+}
+
+/**
+ * Replaces all matches in element.innerHTML with their replacements, as
+ * encoded in the rules string.
+ *
+ * @param {{words:string[],replacement:string, audio_url:string}[]} replacements
+ * @param {HTMLElement} element
+ */
+function replaceAll(replacements, element) {
+  recursiveReplace(replacements, element);
 }


### PR DESCRIPTION
The work "chapter index" and "download" buttons appear to work again after this change :tada: 

After this change, the only elements that actually get *replaced* are text nodes. I'm not an html expert, but if text nodes can have actions associated with them, that would get broken by this replacement, something is very wrong. Since other nodes are merely having their children modified, no actions/listeners associated with them should be affected, so the class-based check I proposed in #4 ends up being unnecessary.