### PR TITLE
Better word boundaries

### DIFF
--- a/Tone_Marks.pub.user.js
+++ b/Tone_Marks.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks
 // @namespace    http://tampermonkey.net/
-// @version      4.3.1
+// @version      4.3.2
 // clang-format off
 // @description  Add tone marks on Ao3 works
 // @author       Cathalinaheart, irrationalpie7

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.3.1
+// @version      4.3.2
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7

--- a/replace.js
+++ b/replace.js
@@ -25,14 +25,23 @@ function escaped(unsafe) {
  * @return {RegExp}
  */
 function wordsMatchRegex(words) {
+  // Use negative look-behind and look-ahead to make sure the character(s)
+  // around a match aren't letters, whether or not they have accent marks.
   return new RegExp(
-      '(<[a-z]+ [^>]*)?\\b(' +
+      // optionally match an incomplete html tag
+      '(<[a-z]+ [^>]*)?' +
+          // Check for word boundary to make sure we're not e.g. replacing lan in the word plant
+          // or the second jie in jiějie
+          '(?<![a-zA-ZÀ-öø-ɏ])' +
+          '(' +
           words
               .map(
                   word =>
                       escaped(word).replace(/([.?*+^$[\]\\(){}|])/g, '\\$1'))
-              .join('( |-)?') +
-          ')\\b',
+              .join('( |-|\')?') +
+          ')' +
+          // Check word boundary
+          '(?![a-zA-ZÀ-öø-ɏ])',
       'gi');
 }
 


### PR DESCRIPTION
Ideally, this script should not make replacements of partial words (e.g., turning plan into pLán), however it can struggle if the word already has accent marks in it, since it only really considers the basic letters a-z and A-Z when detecting word boundaries. For example, the AO3 tag for Wen Ning comes pre-marked with pinyin accents ([Wēn Níng | Wēn Qiónglín](https://archiveofourown.org/tags/W%C4%93n%20N%C3%ADng%20%7C%20W%C4%93n%20Qi%C3%B3ngl%C3%ADn/works)) which, since the script doesn't realize the ó in Qiónglín is internal to the word, leads to it replacing the initial "Qi" with "Qì" (Wēn Níng | Wēn *_Qì_*ónglín).

This change replaces the \b special regex word boundary shortcut with look-ahead/behind to exclude a more expanded class of letters. I picked [a-zA-ZÀ-öø-ɏ] by going to the [Wikipedia article on Latin unicode characters](https://en.wikipedia.org/wiki/List_of_Unicode_characters#Latin_script) and trying to pick outer limits of anything that looked letter-like. It seems to fix the Qionglin issue, so I'll declare it good enough.