### PR TITLE
Show glossary

### DIFF
--- a/Tone_Marks.pub.user.js
+++ b/Tone_Marks.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks
 // @namespace    http://tampermonkey.net/
-// @version      4.3
+// @version      4.3.3
 // clang-format off
 // @description  Add tone marks on Ao3 works
 // @author       Cathalinaheart, irrationalpie7

--- a/Tone_Marks.pub.user.js
+++ b/Tone_Marks.pub.user.js
@@ -13,6 +13,7 @@
 // @require      check-fandoms.js
 // @require      show-glossary.js
 // @require      mark-tones.js
+// @resource     glossary_css glossary.css
 // Generic and per-fandom replacement rules:
 // @resource     generic resources/generic.txt
 // @resource     guardian resources/guardian.txt

--- a/Tone_Marks.pub.user.js
+++ b/Tone_Marks.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks
 // @namespace    http://tampermonkey.net/
-// @version      4.3.3
+// @version      4.3.4
 // clang-format off
 // @description  Add tone marks on Ao3 works
 // @author       Cathalinaheart, irrationalpie7
@@ -11,6 +11,7 @@
 //
 // @require      replace.js
 // @require      check-fandoms.js
+// @require      show-glossary.js
 // @require      mark-tones.js
 // Generic and per-fandom replacement rules:
 // @resource     generic https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/generic.txt
@@ -23,8 +24,10 @@
 // @resource     svsss https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/svsss.txt
 // @resource     jwqs https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/jwqs.txt
 // @resource     erha https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/erha.txt
+// @resource     glossary_css glossary.css
 // clang-format on
 // @grant GM.getResourceUrl
+// @grant GM_getResourceText
 // @grant GM_addStyle
 // ==/UserScript==
 
@@ -32,4 +35,7 @@
   'use strict';
 
   await doToneMarksReplacement(/*includeAudio=*/ false);
+
+  const glossary_css = GM_getResourceText('glossary_css');
+  GM_addStyle(glossary_css);
 })();

--- a/Tone_Marks.pub.user.js
+++ b/Tone_Marks.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks
 // @namespace    http://tampermonkey.net/
-// @version      4.3.6
+// @version      4.4
 // clang-format off
 // @description  Add tone marks on Ao3 works
 // @author       Cathalinaheart, irrationalpie7

--- a/Tone_Marks.pub.user.js
+++ b/Tone_Marks.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks
 // @namespace    http://tampermonkey.net/
-// @version      4.3.5
+// @version      4.3.6
 // clang-format off
 // @description  Add tone marks on Ao3 works
 // @author       Cathalinaheart, irrationalpie7

--- a/Tone_Marks.pub.user.js
+++ b/Tone_Marks.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks
 // @namespace    http://tampermonkey.net/
-// @version      4.3.4
+// @version      4.3.5
 // clang-format off
 // @description  Add tone marks on Ao3 works
 // @author       Cathalinaheart, irrationalpie7

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.3
+// @version      4.3.3
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.3.4
+// @version      4.3.5
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7
@@ -27,6 +27,7 @@
 // @resource     erha https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/erha.txt
 // @resource     IMPORTED_CSS https://fonts.googleapis.com/icon?family=Material+Icons
 // @resource     audio_css audio.css
+// @resource     glossary_css glossary.css
 // clang-format on
 // @grant GM.getResourceUrl
 // @grant GM_getResourceText
@@ -42,4 +43,6 @@
   GM_addStyle(icon_css);
   const audio_button_css = GM_getResourceText('audio_css');
   GM_addStyle(audio_button_css);
+  const glossary_css = GM_getResourceText('glossary_css');
+  GM_addStyle(glossary_css);
 })();

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.3.3
+// @version      4.3.4
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7
@@ -12,6 +12,7 @@
 // @require      audio.js
 // @require      replace.js
 // @require      check-fandoms.js
+// @require      show-glossary.js
 // @require      mark-tones.js
 // Generic and per-fandom replacement rules:
 // @resource     generic https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/resources/generic.txt

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.3.6
+// @version      4.4
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.3.5
+// @version      4.3.6
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7

--- a/audio.js
+++ b/audio.js
@@ -2,12 +2,10 @@
 /**
  * Surround span with a button that plays/pauses the audio.
  * @param {HTMLElement} span
- * @param {string} outerClass
  */
-function addAudioButtonAround(span, outerClass) {
+function addAudioButtonAround(span) {
   const button = document.createElement('button');
   button.classList.add('tone-audio-button');
-  button.classList.add(outerClass);
 
   // Group the pinyin and the progress indicator so they're the same length.
   const progressGroup = document.createElement('div');

--- a/audio.js
+++ b/audio.js
@@ -2,10 +2,12 @@
 /**
  * Surround span with a button that plays/pauses the audio.
  * @param {HTMLElement} span
+ * @param {string} outerClass
  */
-function addAudioButtonAround(span) {
+function addAudioButtonAround(span, outerClass) {
   const button = document.createElement('button');
   button.classList.add('tone-audio-button');
+  button.classList.add(outerClass);
 
   // Group the pinyin and the progress indicator so they're the same length.
   const progressGroup = document.createElement('div');

--- a/glossary.css
+++ b/glossary.css
@@ -1,5 +1,6 @@
+/* Display the glossary in columns, as it's likely to be a long thing list. */
 .glossary-list {
-    columns: auto 8em;
+    columns: auto 10em;
     border-style: solid;
     border-width: thin;
     padding: 10px;
@@ -7,7 +8,28 @@
 
 .glossary-list .glossary-list-item {
     display: list-item;
-    margin-top: 0px;
+    padding-left: 0px;
+    margin-left: 1em;
+    margin-bottom: 3px;
+    list-style: disc outside;
+}
+
+/* Wrap text within an audio button if it's too long for the column. */
+.glossary-list .tone-audio-button {
+    white-space: normal;
+    overflow-wrap: normal;
+    height: 100%;
+    text-align: left;
+}
+
+/* Don't underline glossary terms that don't have audio. */
+.glossary-list .replacement {
+    text-decoration: none;
+}
+
+/* DO underline glossary terms that DO have audio. */
+.glossary-list .tone-audio-button .replacement {
+    text-decoration: underline;
 }
 
 .hide-glossary {

--- a/glossary.css
+++ b/glossary.css
@@ -1,0 +1,14 @@
+.glossary {
+    border-style: double;
+    width: 100%;
+}
+
+.glossary-list {
+    columns: auto 6em;
+    /* todo: fancy border or some such?*/
+}
+
+/* https://stackoverflow.com/questions/6605979/how-do-i-get-css-columns-to-play-properly-with-margins */
+.glossary-list>* {
+    margin-top: 0px;
+}

--- a/glossary.css
+++ b/glossary.css
@@ -1,14 +1,15 @@
-.glossary {
-    border-style: double;
-    width: 100%;
-}
-
 .glossary-list {
-    columns: auto 6em;
-    /* todo: fancy border or some such?*/
+    columns: auto 8em;
+    border-style: solid;
+    border-width: thin;
+    padding: 10px;
 }
 
-/* https://stackoverflow.com/questions/6605979/how-do-i-get-css-columns-to-play-properly-with-margins */
-.glossary-list>* {
+.glossary-list .glossary-list-item {
+    display: list-item;
     margin-top: 0px;
+}
+
+.hide-glossary {
+    display: none;
 }

--- a/mark-tones.js
+++ b/mark-tones.js
@@ -19,7 +19,8 @@ async function doToneMarksReplacement(includeAudio) {
       await doReplacements(document.getElementById('main'));
 
       // Generate glossary. Note that this will add new '.replacement' elements.
-      generateGlossary(Array.from(document.querySelectorAll('.replacement')));
+      generateGlossary(
+          Array.from(document.querySelectorAll('.replacement')), document);
     }
   } else {
     console.log(

--- a/mark-tones.js
+++ b/mark-tones.js
@@ -13,10 +13,13 @@ async function doToneMarksReplacement(includeAudio) {
 
   if (url.match(works_regex) !== null) {
     if (url.match(edit_page_regex) === null && !url.includes('works/new')) {
-      console.log('On a works page, potentially making pinyin replacements...')
-          // Don't make replacements on the new work/edit work (tag) page,
-          // that sounds confusing.
-          await doReplacements(document.getElementById('main'));
+      console.log('On a works page, potentially making pinyin replacements...');
+      // Don't make replacements on the new work/edit work (tag) page,
+      // that sounds confusing.
+      await doReplacements(document.getElementById('main'));
+
+      // Generate glossary. Note that this will add new '.replacement' elements.
+      generateGlossary(Array.from(document.querySelectorAll('.replacement')));
     }
   } else {
     console.log(
@@ -33,9 +36,7 @@ async function doToneMarksReplacement(includeAudio) {
   replacements.forEach(span => {
     span.innerHTML = span.dataset.new;
     if (includeAudio && span.dataset.url !== 'None') {
-      addAudioButtonAround(span, 'tone-mark');
-    } else {
-      span.classList.add('tone-mark');
+      addAudioButtonAround(span);
     }
   });
 }

--- a/mark-tones.js
+++ b/mark-tones.js
@@ -33,7 +33,9 @@ async function doToneMarksReplacement(includeAudio) {
   replacements.forEach(span => {
     span.innerHTML = span.dataset.new;
     if (includeAudio && span.dataset.url !== 'None') {
-      addAudioButtonAround(span);
+      addAudioButtonAround(span, 'tone-mark');
+    } else {
+      span.classList.add('tone-mark');
     }
   });
 }

--- a/show-glossary.js
+++ b/show-glossary.js
@@ -1,0 +1,46 @@
+function generateGlossary(element) {}
+
+/**
+ * Generate a glossary for all replacements present in element.
+ * @param {HTMLElement} element
+ */
+function generateGlossaryList(element) {
+  // Sort replacements and filter by the new (replaced) version of a word, e.g.
+  // jiějie
+  const map = new Map(
+      Array.from(element.querySelectorAll('.tone-mark'))
+          .sort(
+              (a, b) =>
+                  getReplacementText(a).localeCompare(getReplacementText(b)))
+          .map(
+              (replacement) => [getReplacementText(replacement), replacement]));
+  const glossaryList = element.ownerDocument.createElement('ul');
+  glossaryList.classList.add('glossary-list');
+  map.forEach(
+      (_key, replacement) =>
+          glossaryList.appendChild(generateGlossaryElement(replacement)))
+}
+
+/**
+ * Get the replacement text associated with a particular replacement element
+ * @param {HTMLElement} element
+ * @returns {string}
+ */
+function getReplacementText(element) {
+  if ('new' in element.dataset) {
+    return element.dataset.new;
+  } else {
+    return element.querySelector('.replacement').dataset.new;
+  }
+}
+
+/**
+ * Copy the element and wrap it in an 'li'
+ * @param {HTMLElement} origElement
+ * @returns {HTMLElement}
+ */
+function generateGlossaryElement(origElement) {
+  const listItem = origElement.ownerDocument.createElement('li');
+  listItem.appendChild(origElement.cloneNode())
+  return listItem;
+}

--- a/show-glossary.js
+++ b/show-glossary.js
@@ -3,7 +3,7 @@
  * @param {HTMLElement} replacements
  * @param {HTMLElement} parent
  */
-function generateGlossary(replacements) {
+function generateGlossary(replacements, parent) {
   // Document positioning. Note: this selector only works on a work page.
   const metaDescriptionList = parent.querySelector('dl.work.meta.group');
   if (metaDescriptionList === null) {

--- a/show-glossary.js
+++ b/show-glossary.js
@@ -1,24 +1,65 @@
-function generateGlossary(element) {}
+/**
+ * Generate an expandable/collapsable glossary for a work page.
+ * @param {HTMLElement} replacements
+ * @param {HTMLElement} parent
+ */
+function generateGlossary(replacements) {
+  // Document positioning. Note: this selector only works on a work page.
+  const metaDescriptionList = parent.querySelector('dl.work.meta.group');
+  if (metaDescriptionList === null) {
+    console.log(
+        'Unable to determine where to insert glossary--aborting glossary generation.');
+    return;
+  }
+
+  const glossaryTitle = document.createElement('dt');
+  glossaryTitle.textContent = 'Glossary';
+  glossaryTitle.classList.add('tone-glossary');
+  metaDescriptionList.appendChild(glossaryTitle);
+  const glossaryContents = document.createElement('dd');
+  glossaryContents.classList.add('tone-glossary');
+  metaDescriptionList.appendChild(glossaryContents);
+
+  // Glossary setup.
+  const glossaryList = generateGlossaryList(replacements)
+  const showHideButton = document.createElement('button');
+  showHideButton.textContent = 'Show tone glossary';
+  showHideButton.addEventListener('click', () => {
+    if (glossaryList.classList.contains('hide-glossary')) {
+      glossaryList.classList.remove('hide-glossary');
+      showHideButton.textContent = 'Hide tone glossary';
+    } else {
+      glossaryList.classList.add('hide-glossary');
+      showHideButton.textContent = 'Show tone glossary';
+    }
+  });
+  glossaryContents.appendChild(showHideButton);
+  glossaryContents.appendChild(glossaryList);
+}
 
 /**
- * Generate a glossary for all replacements present in element.
- * @param {HTMLElement} element
+ * Generate a glossary list for a list of replacements, sorting and removing
+ * duplicates.
+ * @param {HTMLElement[]} replacements
+ * @returns {HTMLElement}
  */
-function generateGlossaryList(element) {
+function generateGlossaryList(replacements) {
   // Sort replacements and filter by the new (replaced) version of a word, e.g.
   // jiějie
   const map = new Map(
-      Array.from(element.querySelectorAll('.tone-mark'))
+      replacements
           .sort(
               (a, b) =>
                   getReplacementText(a).localeCompare(getReplacementText(b)))
           .map(
               (replacement) => [getReplacementText(replacement), replacement]));
-  const glossaryList = element.ownerDocument.createElement('ul');
+  const glossaryList = document.createElement('ul');
   glossaryList.classList.add('glossary-list');
+  glossaryList.classList.add('hide-glossary')
   map.forEach(
-      (_key, replacement) =>
-          glossaryList.appendChild(generateGlossaryElement(replacement)))
+      (replacement, _key) =>
+          glossaryList.appendChild(generateGlossaryElement(replacement)));
+  return glossaryList;
 }
 
 /**
@@ -27,11 +68,7 @@ function generateGlossaryList(element) {
  * @returns {string}
  */
 function getReplacementText(element) {
-  if ('new' in element.dataset) {
-    return element.dataset.new;
-  } else {
-    return element.querySelector('.replacement').dataset.new;
-  }
+  return element.dataset.new;
 }
 
 /**
@@ -41,6 +78,7 @@ function getReplacementText(element) {
  */
 function generateGlossaryElement(origElement) {
   const listItem = origElement.ownerDocument.createElement('li');
-  listItem.appendChild(origElement.cloneNode())
+  listItem.classList.add('glossary-list-item');
+  listItem.appendChild(origElement.cloneNode(true));
   return listItem;
 }

--- a/show-glossary.js
+++ b/show-glossary.js
@@ -13,7 +13,7 @@ function generateGlossary(replacements, parent) {
   }
 
   const glossaryTitle = document.createElement('dt');
-  glossaryTitle.textContent = 'Glossary';
+  glossaryTitle.textContent = 'Glossary:';
   glossaryTitle.classList.add('tone-glossary');
   metaDescriptionList.appendChild(glossaryTitle);
   const glossaryContents = document.createElement('dd');


### PR DESCRIPTION
This change allows users to preview what (known) words show up in the current work (or chapter of it, if you're looking at a single chapter of a multi-chapter work).

It displays this glossary in the metadata box for a work, below the stats like publication date, and allows users to show or hide the words with a button. Words that have audio are underlined and allow playback; words that don't are not. Otherwise, individual words/phrases display identically to the way the replacements normally display for a user. Replacements are displayed in columns to reduce required vertical space, since the list of words or phrases may be long but is likely thin.

Here's what that looks like for an example work (ignore most of the coloring; that's specific to how I view ao3):
![image](https://user-images.githubusercontent.com/76858438/211685003-ad2dbfd5-42a5-4b4a-9c80-13324fb36660.png)