### PR TITLE
Error catching/(script)monkey compatibility

### DIFF
--- a/Tone_Marks.pub.user.js
+++ b/Tone_Marks.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks
 // @namespace    http://tampermonkey.net/
-// @version      4.4
+// @version      4.5
 // clang-format off
 // @description  Add tone marks on Ao3 works
 // @author       Cathalinaheart, irrationalpie7
@@ -9,6 +9,7 @@
 // @updateURL    https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/Tone_Marks.pub.user.js
 // @downloadURL  https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/Tone_Marks.pub.user.js
 //
+// @require      monkey-compatibility.js
 // @require      replace.js
 // @require      check-fandoms.js
 // @require      show-glossary.js
@@ -36,6 +37,5 @@
 
   await doToneMarksReplacement(/*includeAudio=*/ false);
 
-  const glossary_css = GM_getResourceText('glossary_css');
-  GM_addStyle(glossary_css);
+  injectCssResource('glossary_css');
 })();

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.4
+// @version      4.5
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7
@@ -9,6 +9,7 @@
 // @updateURL    https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/Tone_Marks_withAudio.pub.user.js
 // @downloadURL  https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/Tone_Marks_withAudio.pub.user.js
 //
+// @require      monkey-compatibility.js
 // @require      audio.js
 // @require      replace.js
 // @require      check-fandoms.js
@@ -39,10 +40,7 @@
 
   await doToneMarksReplacement(/*includeAudio=*/ true);
 
-  const icon_css = GM_getResourceText('IMPORTED_CSS');
-  GM_addStyle(icon_css);
-  const audio_button_css = GM_getResourceText('audio_css');
-  GM_addStyle(audio_button_css);
-  const glossary_css = GM_getResourceText('glossary_css');
-  GM_addStyle(glossary_css);
+  injectCssResource('IMPORTED_CSS');
+  injectCssResource('audio_css');
+  injectCssResource('glossary_css');
 })();

--- a/check-fandoms.js
+++ b/check-fandoms.js
@@ -115,12 +115,26 @@ function splitReplacements(replacements) {
             replacement: match[1].trim(),
             audio_url: match[2].trim()
           };
-        } else {
+        }
+        if (match.length === 2 && match[1].trim() !== '') {
           return {
             words: match[0].split(' ').filter(match => match.length > 0),
             replacement: match[1].trim(),
             audio_url: 'None'
           };
         }
+        // Hacky error case.
+        return {
+          words: [], replacement: null, audio_url: line
+        }
+      })
+      .filter(replacement => {
+        // Log the hacky error case.
+        if (replacement.replacement === null) {
+          console.log(
+              'Skipping invalid replacement rule: \'' + replacement.audio_url +
+              '\'');
+        }
+        return replacement.replacement !== null;
       });
 }

--- a/check-fandoms.js
+++ b/check-fandoms.js
@@ -79,7 +79,7 @@ async function getReplacementRules(workFandoms) {
  * @param {string} fandom
  */
 async function getReplacements(fandom) {
-  return GM_getResourceText(fandom);
+  return getResourceText(fandom)
 }
 
 /**

--- a/check-fandoms.js
+++ b/check-fandoms.js
@@ -79,13 +79,7 @@ async function getReplacementRules(workFandoms) {
  * @param {string} fandom
  */
 async function getReplacements(fandom) {
-  return GM.getResourceUrl(fandom)
-      .then(url => fetch(url))
-      .then(resp => resp.text())
-      .catch(function(error) {
-        console.log('Request failed', error);
-        return null;
-      });
+  return GM_getResourceText(fandom);
 }
 
 /**

--- a/check-fandoms.js
+++ b/check-fandoms.js
@@ -117,5 +117,6 @@ function splitReplacements(replacements) {
           // Set audio_url if it exists, otherwise set to 'None'.
           audio_url: match.length >= 3 ? match[2].trim() : 'None'
         });
+        return rules;
       }, []);
 }

--- a/check-fandoms.js
+++ b/check-fandoms.js
@@ -79,7 +79,7 @@ async function getReplacementRules(workFandoms) {
  * @param {string} fandom
  */
 async function getReplacements(fandom) {
-  return getResourceText(fandom)
+  return getResourceText(fandom);
 }
 
 /**
@@ -95,13 +95,9 @@ async function getReplacements(fandom) {
  */
 function splitReplacements(replacements) {
   return replacements.split('\n')
-      .map(function(line) {
-        return line.trim();
-      })
-      .filter(function(line) {
-        return line.length > 0 && !line.startsWith('#');
-      })
-      .map(function(line) {
+      .map(line => line.trim())
+      .filter(line => line.length > 0 && !line.startsWith('#'))
+      .map(line => {
         const match = line.split('|');
         if (match.length === 3) {
           return {

--- a/monkey-compatibility.js
+++ b/monkey-compatibility.js
@@ -1,0 +1,27 @@
+/**
+ * Fetch the text of a (script)monkey resource.
+ * @param {string} resourceName
+ */
+async function getResourceText(resourceName) {
+  try {
+    GM_getResourceText(resourceName);
+  } catch (e) {
+    if (e instanceof ReferenceError) {
+      return GM.getResourceUrl(fandom)
+          .then(url => fetch(url))
+          .then(resp => resp.text())
+          .catch(function(error) {
+            console.log('Request failed', error);
+            return null;
+          });
+    }
+  }
+}
+
+/**
+ * Inject this css resource into the current page.
+ * @param {string} cssResourceName
+ */
+async function injectCssResource(cssResourceName) {
+  getResourceText('glossary_css').then(css => GM_addStyle(css));
+}

--- a/monkey-compatibility.js
+++ b/monkey-compatibility.js
@@ -23,5 +23,14 @@ async function getResourceText(resourceName) {
  * @param {string} cssResourceName
  */
 async function injectCssResource(cssResourceName) {
-  getResourceText('glossary_css').then(css => GM_addStyle(css));
+  const cssText = await getResourceText(cssResourceName);
+  try {
+    GM_addStyle(cssText);
+  } catch (e) {
+    if (e instanceof ReferenceError) {
+      var style = document.createElement('style');
+      style.innerHTML = cssText;
+      document.head.appendChild(style);
+    }
+  }
 }

--- a/monkey-compatibility.js
+++ b/monkey-compatibility.js
@@ -7,7 +7,7 @@ async function getResourceText(resourceName) {
     GM_getResourceText(resourceName);
   } catch (e) {
     if (e instanceof ReferenceError) {
-      return GM.getResourceUrl(fandom)
+      return GM.getResourceUrl(resourceName)
           .then(url => fetch(url))
           .then(resp => resp.text())
           .catch(function(error) {

--- a/monkey-compatibility.js
+++ b/monkey-compatibility.js
@@ -4,7 +4,7 @@
  */
 async function getResourceText(resourceName) {
   try {
-    GM_getResourceText(resourceName);
+    return GM_getResourceText(resourceName);
   } catch (e) {
     if (e instanceof ReferenceError) {
       return GM.getResourceUrl(resourceName)


### PR DESCRIPTION
I've installed various (script)monkey extensions over the course of working on this extension. Today, I happened to have violent monkey on and it was totally failing to parse fandom rules, so I added some checking to log and skip invalid rules rather than crashing. Then it turned out fetching GM.getResourceUrl was returning the current page rather than the fandom.txt resource??? So then I wanted to use GM_getResourceText instead, only that doesn't exist in grease monkey, so I ended up adding `monkey-compatibility.js` to try GM_getResourceText and fall back to the other version if necessary. And while I was at it did the same for GM_addStyle.

I've now tested audio and non-audio versions with greasemonkey and violentmonkey in firefox, and tampermonkey in chrome, so I hope it actually works for everyone.