### PR TITLE
Hide empty glossary

### DIFF
--- a/show-glossary.js
+++ b/show-glossary.js
@@ -1,9 +1,14 @@
 /**
  * Generate an expandable/collapsable glossary for a work page.
- * @param {HTMLElement} replacements
+ * @param {HTMLElement[]} replacements
  * @param {HTMLElement} parent
  */
 function generateGlossary(replacements, parent) {
+  if (replacements.length === 0) {
+    console.log(
+        'No replacements to make a glossary for--aborting glossary generation.')
+  }
+
   // Document positioning. Note: this selector only works on a work page.
   const metaDescriptionList = parent.querySelector('dl.work.meta.group');
   if (metaDescriptionList === null) {

--- a/show-glossary.js
+++ b/show-glossary.js
@@ -6,7 +6,8 @@
 function generateGlossary(replacements, parent) {
   if (replacements.length === 0) {
     console.log(
-        'No replacements to make a glossary for--aborting glossary generation.')
+        'No replacements to make a glossary for--aborting glossary generation.');
+    return;
   }
 
   // Document positioning. Note: this selector only works on a work page.


### PR DESCRIPTION
Abort glossary generation if the script didn't actually make any replacements.

Note: I used some shenanigans to test this and I think it works? But without the other fix in yet it's hard to be confident about it.