### PR TITLE
Refactor rules parsing (draft)

### DIFF
--- a/Tone_Marks.pub.user.js
+++ b/Tone_Marks.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks
 // @namespace    http://tampermonkey.net/
-// @version      4.5
+// @version      4.5.1
 // clang-format off
 // @description  Add tone marks on Ao3 works
 // @author       Cathalinaheart, irrationalpie7
@@ -10,6 +10,7 @@
 // @downloadURL  https://github.com/Cathalinaheart/AO3-Tone-Marks/raw/main/Tone_Marks.pub.user.js
 //
 // @require      monkey-compatibility.js
+// @require      rules.js
 // @require      replace.js
 // @require      check-fandoms.js
 // @require      show-glossary.js

--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.5
+// @version      4.5.1
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7
@@ -11,6 +11,7 @@
 //
 // @require      monkey-compatibility.js
 // @require      audio.js
+// @require      rules.js
 // @require      replace.js
 // @require      check-fandoms.js
 // @require      show-glossary.js

--- a/check-fandoms.js
+++ b/check-fandoms.js
@@ -1,17 +1,19 @@
 /**
  * Checks whether 'fandomNames' (ignoring case) is a substring of any of the
- * fandom tags, and if so appends the relevant rules.
+ * fandom tags, and if so appends the list of relevant rules.
  *
  * @param {string} fandomNames
  * @param {string} fandomId
  * @param {Element[]} fandomTags
- * @param {{asString:string}} rules
+ * @param {Rule[][]} rules
  */
 async function updateRulesForFandom(fandomNames, fandomId, fandomTags, rules) {
   const fandomRegex = new RegExp(fandomNames, 'i');
   for (let i = 0; i < fandomTags.length; i++) {
     if (fandomTags[i].innerHTML.match(fandomRegex) !== null) {
-      rules.asString += await getReplacements(fandomId) + '\n';
+      getReplacements(fandomId)
+          .then(rulesString => parseRules(rulesString, fandomId))
+          .then(rulesArray => rules.push(rulesArray));
       return;
     }
   }
@@ -30,11 +32,7 @@ function getFandomTags(element) {
  * Gets the replacement rules for an element, based on its fandom tags.
  *
  * @param {HTMLElement[]} workFandoms The fandom tags for this work.
- *
- * @returns {{words:string[],replacement:string, audio_url:string}[]} A list of
- *     replacement rules. Each rule consists of a list of word(s) to replace,
- *     what they should be replaced with, and potentially an audio_url with
- *     pronunciation.
+ * @returns {Promise<Rule[]>} A list of replacement rules (see rules.js)
  */
 async function getReplacementRules(workFandoms) {
   // If there's no fandoms, there can be no replacement rules.
@@ -43,8 +41,7 @@ async function getReplacementRules(workFandoms) {
     return [];
   }
 
-  // Yay hacky mutable string.
-  const rules = {asString: ''}
+  const rules = [];
 
   // To add new fandom, copy commented line and update 'fandom_names' and 'id':
   // await updateRulesForFandom('fandom_names', 'id', workFandoms, rules);
@@ -71,52 +68,13 @@ async function getReplacementRules(workFandoms) {
   // Add non-fandom-specific rules at the end.
   await updateRulesForFandom('', 'generic', workFandoms, rules);
 
-  return splitReplacements(rules.asString);
+  return sortedRules(rules.flat());
 }
 
 /**
  * Loads the replacement string for this fandom from its <fandom>.txt file.
- * @param {string} fandom
+ * @param {Promise<string>} fandom
  */
 async function getReplacements(fandom) {
   return getResourceText(fandom);
-}
-
-/**
- * Turns a long replacements string into a list of match objects, where:
- *  - match.words is an array of strings that form the individual words to
- * match
- *  - match.replacement is the text to replace that sequence with
- *  - match.audio_url is an optional url pointing to audio that pronounces this
- * text.
- *
- * @param {string} replacements
- * @returns {{words:string[],replacement:string, audio_url:string}[]}
- */
-function splitReplacements(replacements) {
-  return replacements
-      .split('\n')
-      // Trim comments (anything after #) and whitespace.
-      .map(line => line.split('#')[0].trim())
-      // Remove empty lines.
-      .filter(line => line.length > 0)
-      // Parse rules
-      .reduce((rules, line) => {
-        const match = line.split('|');
-
-        // Check replacement validity.
-        if (match.length < 2 || match[1].trim() === '') {
-          console.log(
-              `Invalid replacement rule--no replacement specified:\n${line}`);
-          return;
-        }
-
-        rules.push({
-          words: match[0].split(' ').filter(match => match.length > 0),
-          replacement: match[1].trim(),
-          // Set audio_url if it exists, otherwise set to 'None'.
-          audio_url: match.length >= 3 ? match[2].trim() : 'None'
-        });
-        return rules;
-      }, []);
 }

--- a/check-fandoms.js
+++ b/check-fandoms.js
@@ -1,22 +1,22 @@
 /**
- * Checks whether 'fandomNames' (ignoring case) is a substring of any of the
- * fandom tags, and if so appends the list of relevant rules.
+ * Checks the list of work tags to see if they mention this fandom, and if yes,
+ * fetches the fandom's rules
  *
- * @param {string} fandomNames
- * @param {string} fandomId
- * @param {Element[]} fandomTags
- * @param {Rule[][]} rules
+ * @param {string} fandomNames alternative fandom names that might be present in
+ *     work tags
+ * @param {string} fandomId id for fetching the rules
+ * @param {Element[]} fandomTags the work's fandom tags
+ * @returns {Promise<Rule[]>} the fandom rules, if applicable
  */
-async function updateRulesForFandom(fandomNames, fandomId, fandomTags, rules) {
+async function fetchRelevantFandomRules(fandomNames, fandomId, fandomTags) {
   const fandomRegex = new RegExp(fandomNames, 'i');
   for (let i = 0; i < fandomTags.length; i++) {
     if (fandomTags[i].innerHTML.match(fandomRegex) !== null) {
-      getReplacements(fandomId)
-          .then(rulesString => parseRules(rulesString, fandomId))
-          .then(rulesArray => rules.push(rulesArray));
-      return;
+      return getReplacements(fandomId).then(
+          rulesString => parseRules(rulesString, fandomId));
     }
   }
+  return [];
 }
 
 /**
@@ -31,44 +31,42 @@ function getFandomTags(element) {
 /**
  * Gets the replacement rules for an element, based on its fandom tags.
  *
- * @param {HTMLElement[]} workFandoms The fandom tags for this work.
+ * @param {HTMLElement[]} fandomTags
  * @returns {Promise<Rule[]>} A list of replacement rules (see rules.js)
  */
-async function getReplacementRules(workFandoms) {
+async function getReplacementRules(fandomTags) {
   // If there's no fandoms, there can be no replacement rules.
-  if (workFandoms.length === 0) {
+  if (fandomTags.length === 0) {
     console.log('Didn\'t detect any fandoms--no replacements possible.')
     return [];
   }
 
-  const rules = [];
+  const rules = [
+    // To add new fandom, copy commented line and update 'fandom_names' and
+    // 'id':
+    // fetchRelevantFandomRules('fandom_names', 'id', fandomTags),
+    fetchRelevantFandomRules(
+        'Word of Honor|Faraway Wanderers|Qi Ye', 'word_of_honor', fandomTags),
+    fetchRelevantFandomRules('Untamed|Módào', 'mdzs', fandomTags),
+    fetchRelevantFandomRules('Guardian', 'guardian', fandomTags),
+    fetchRelevantFandomRules('Nirvana in Fire', 'nirvana_in_fire', fandomTags),
+    fetchRelevantFandomRules(
+        'King\'s Avatar|Quánzhí Gāoshǒu', 'kings_avatar', fandomTags),
+    fetchRelevantFandomRules(
+        'TGCF|Tiān Guān Cì Fú|Heaven Official\'s Blessing', 'tgcf', fandomTags),
+    fetchRelevantFandomRules(
+        'SVSSS|Scum Villain|Scumbag System', 'svsss', fandomTags),
+    fetchRelevantFandomRules(
+        'JWQS|Clear and Muddy Loss of Love|Jing Wei Qing Shang', 'jwqs',
+        fandomTags),
+    fetchRelevantFandomRules(
+        '2ha|erha|Husky and His White Cat Shizun', 'erha', fandomTags),
 
-  // To add new fandom, copy commented line and update 'fandom_names' and 'id':
-  // await updateRulesForFandom('fandom_names', 'id', workFandoms, rules);
-  await updateRulesForFandom(
-      'Word of Honor|Faraway Wanderers|Qi Ye', 'word_of_honor', workFandoms,
-      rules);
-  await updateRulesForFandom('Untamed|Módào', 'mdzs', workFandoms, rules);
-  await updateRulesForFandom('Guardian', 'guardian', workFandoms, rules);
-  await updateRulesForFandom(
-      'Nirvana in Fire', 'nirvana_in_fire', workFandoms, rules);
-  await updateRulesForFandom(
-      'King\'s Avatar|Quánzhí Gāoshǒu', 'kings_avatar', workFandoms, rules);
-  await updateRulesForFandom(
-      'TGCF|Tiān Guān Cì Fú|Heaven Official\'s Blessing', 'tgcf', workFandoms,
-      rules);
-  await updateRulesForFandom(
-      'SVSSS|Scum Villain|Scumbag System', 'svsss', workFandoms, rules);
-  await updateRulesForFandom(
-      'JWQS|Clear and Muddy Loss of Love|Jing Wei Qing Shang', 'jwqs',
-      workFandoms, rules);
-  await updateRulesForFandom(
-      '2ha|erha|Husky and His White Cat Shizun', 'erha', workFandoms, rules);
+    // Add non-fandom-specific rules at the end.
+    fetchRelevantFandomRules('', 'generic', fandomTags)
+  ];
 
-  // Add non-fandom-specific rules at the end.
-  await updateRulesForFandom('', 'generic', workFandoms, rules);
-
-  return sortedRules(rules.flat());
+  return Promise.all(rules).then(rules => sortedRules(rules.flat()));
 }
 
 /**

--- a/replace.js
+++ b/replace.js
@@ -1,84 +1,18 @@
 /**
- * Replaces special html characters.
- * @param {string} str
- * @returns {string}
- */
-function escaped(unsafe) {
-  return (unsafe + '')
-      .replaceAll('&', '&amp;')
-      .replaceAll('<', '&lt;')
-      .replaceAll('>', '&gt;')
-      .replaceAll('"', '&quot;')
-      .replaceAll('\'', '&#039;');
-}
-
-/**
- * Returns a regex to match a sequence of words, allowing an optional
- * dash (-) or space ( ) between each word. The beginning and end of the
- * matching sequence must be at a word boundary.
- *
- * The regex will also match an incomplete html tag preceding the match,
- * which you can check for to avoid replacing within an html tag's
- * attributes.
- *
- * @param {string[]} words
- * @return {RegExp}
- */
-function wordsMatchRegex(words) {
-  // Use negative look-behind and look-ahead to make sure the character(s)
-  // around a match aren't letters, whether or not they have accent marks.
-  return new RegExp(
-      // optionally match an incomplete html tag
-      '(<[a-z]+ [^>]*)?' +
-          // Check for word boundary to make sure we're not e.g. replacing lan in the word plant
-          // or the second jie in jiějie
-          '(?<![a-zA-ZÀ-öø-ɏ])' +
-          '(' +
-          words
-              .map(
-                  word =>
-                      escaped(word).replace(/([.?*+^$[\]\\(){}|])/g, '\\$1'))
-              .join('( |-|\')?') +
-          ')' +
-          // Check word boundary
-          '(?![a-zA-ZÀ-öø-ɏ])',
-      'gi');
-}
-
-/**
- * Wraps the replacement text in a span and returns the span as a string.
- *
- * The span will have class 'replacement' and attributes 'data-orig' with
- * the original match and 'data-new' with the replacement text.
- * @param {string} replacement The new text
- * @param {string} match The original text which is being replaced
- * @return {string}
- */
-function replacementHtml(replacement, match, audio_url) {
-  return `<span class="replacement" lang="zh-Latn-pinyin"
-            data-orig="${match}"
-            data-new="${escaped(replacement)}"
-            data-url="${audio_url}">
-            ${escaped(replacement)}
-          </span>`;
-}
-
-/**
  * Replaces all occurrences that match 'from' in main's innerHTML with a
  * span whose text is 'to'.
  *
  * @param {{innerHTML: string}} main
- * @param {RegExp} from
- * @param {string} to
+ * @param {Rule} rule
  */
-function replaceTextOnPage(main, from, to, audio_url) {
-  main.innerHTML = main.innerHTML.replace(from, (match) => {
+function replaceTextOnPage(main, rule) {
+  main.innerHTML = main.innerHTML.replace(rule.regex, (match) => {
     if (match.startsWith('<')) {
       // Skip matches occurring inside incomplete html tags. This avoids
       // e.g. replacing within the href for a work tag.
       return match;
     }
-    return replacementHtml(to, match, audio_url);
+    return rule.toHtmlString(match);
   });
 }
 
@@ -100,7 +34,7 @@ function replaceTextNode(textNode, newInnerHtml) {
  * Replaces all matches in element.innerHTML with their replacements, as
  * encoded in the rules string.
  *
- * @param {{words:string[],replacement:string, audio_url:string}[]} replacements
+ * @param {Rule[]} replacements
  * @param {HTMLElement} element
  */
 function recursiveReplace(replacements, element) {
@@ -123,7 +57,7 @@ function recursiveReplace(replacements, element) {
  * Replace text (which is not html) according to the rules in the replacements
  * list, resulting in text with html markup.
  *
- * @param {{words:string[],replacement:string, audio_url:string}[]} replacements
+ * @param {Rule[]} replacements
  * @param {string} text
  * @returns {string} replacement text, which may have html formatting
  */
@@ -131,9 +65,7 @@ function replaceText(replacements, text) {
   // pretend text is part of an element
   const simplifiedElement = {innerHTML: text};
   replacements.forEach(rule => {
-    replaceTextOnPage(
-        simplifiedElement, wordsMatchRegex(rule.words), rule.replacement,
-        rule.audio_url);
+    replaceTextOnPage(simplifiedElement, rule);
   });
   return simplifiedElement.innerHTML;
 }
@@ -142,7 +74,7 @@ function replaceText(replacements, text) {
  * Replaces all matches in element.innerHTML with their replacements, as
  * encoded in the rules string.
  *
- * @param {{words:string[],replacement:string, audio_url:string}[]} replacements
+ * @param {Rule[]} replacements
  * @param {HTMLElement} element
  */
 function replaceAll(replacements, element) {

--- a/rules.js
+++ b/rules.js
@@ -1,0 +1,246 @@
+class Rule {
+  /**
+   * @param {string[]} words
+   * @param {string} replacement
+   * @param {string?} audio_url
+   * @param {string} source
+   */
+  constructor(words, replacement, audio_url, source) {
+    this.words = words;
+    this.regex = wordsMatchRegex(words);
+    this.replacement = replacement;
+    this.audio_url = audio_url;
+    this.source = source;
+  }
+
+  get audio_url() {
+    return this.audio_url ? this.audio_url : 'None';
+  }
+
+  get regex() {
+    return this.regex;
+  }
+
+  /**
+   * @returns {boolean}
+   */
+  has_audio_url() {
+    return this.audio_url && this.audio_url !== 'None';
+  }
+
+  /**
+   * Replaces special html characters.
+   * @param {string} unsafe
+   * @returns {string}
+   */
+  #escaped(unsafe) {
+    return (unsafe + '')
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll('\'', '&#039;');
+  }
+
+
+  /**
+   * Returns a regex to match a sequence of words, allowing an optional
+   * dash (-) or space ( ) between each word. The beginning and end of the
+   * matching sequence must be at a word boundary.
+   *
+   * The regex will also match an incomplete html tag preceding the match,
+   * which you can check for to avoid replacing within an html tag's
+   * attributes.
+   *
+   * @param {string[]} words
+   * @return {RegExp}
+   */
+  #wordsMatchRegex(words) {
+    // Use negative look-behind and look-ahead to make sure the character(s)
+    // around a match aren't letters, whether or not they have accent marks.
+    return new RegExp(
+        // optionally match an incomplete html tag
+        '(<[a-z]+ [^>]*)?' +
+            // Check for word boundary to make sure we're not e.g. replacing lan
+            // in the word plant or the second jie in jiějie
+            '(?<![a-zA-ZÀ-öø-ɏ])' +
+            '(' +
+            words
+                .map(
+                    word =>
+                        escaped(word).replace(/([.?*+^$[\]\\(){}|])/g, '\\$1'))
+                .join('( |-|\')?') +
+            ')' +
+            // Check word boundary
+            '(?![a-zA-ZÀ-öø-ɏ])',
+        'gi');
+  }
+
+  /**
+   * Wraps the replacement text in a span and returns the span as a string.
+   *
+   * The span will have class 'replacement' and attributes 'data-orig' with
+   * the original match and 'data-new' with the replacement text.
+   *
+   * @param {string} match The original text which is being replaced
+   * @return {string}
+   */
+  toHtmlString(match) {
+    return `<span class="replacement" lang="zh-Latn-pinyin"
+              data-orig="${match}"
+              data-new="${escaped(this.replacement)}"
+              data-url="${this.audio_url}"
+              data-fandom="${source}">
+              ${escaped(this.replacement)}
+            </span>`;
+  }
+
+  toString() {
+    return `Match: '${this.words.join(' ')}'; Replacement: '${
+        this.replacement}'; Source: '${this.source}'; Audio url: ${
+        this.has_audio_url() ? this.audio_url : 'None'}`;
+  }
+
+  /**
+   * Checks whether applying this rule would prevent the other rule from being
+   * applied.
+   *
+   * For example, if this rule is "jiang|Jiāng" and it's applied first, and the
+   * other rule is "jiang hu|Jiānghú", then (broadly speaking) by the time we
+   * get to the check for "jiang hu" we'll see "Jiāng hu" and not realize we
+   * need to replace the hu.
+   *
+   * @param {Rule} otherRule
+   */
+  conflictsWith(otherRule) {
+    // To extend the jiang/jianghu metaphor, test whether the regex for "jiang"
+    // would find something to replace in "jiang hu"
+    return this.regex.test(otherRule.words.join(' '));
+  }
+}
+
+/**
+ * Parses a replacements string into an array of Rules.
+ *
+ * @param {string} replacements
+ * @param {string} source E.g. 'mdzs' for rules coming from mdzs.txt
+ * @returns {Rule[]}
+ */
+function parseRules(replacements, source) {
+  return replacements
+      .split('\n')
+      // Trim comments (anything after #) and whitespace.
+      .map(line => line.split('#')[0].trim())
+      // Remove empty lines.
+      .filter(line => line.length > 0)
+      // Parse rules
+      .reduce((rules, line) => {
+        const match = line.split('|');
+
+        // Check replacement validity.
+        if (match.length < 2 || match[1].trim() === '') {
+          console.log(
+              `Invalid replacement rule--no replacement specified:\n${line}`);
+          return;
+        }
+
+        rules.push(new Rule(
+            /* words = */ match[0].split(' ').filter(match => match.length > 0),
+            /* replacement = */ match[1].trim(),
+            /* audio_url = */ match.length >= 3 ? match[2].trim() : 'None',
+            /* source = */ source));
+        return rules;
+      }, []);
+}
+
+/**
+ * Makes a copy of the rules, sorted such that rules which would conflict with
+ * other rules are moved to the end of the list, and the second of any pair of
+ * mutually conflicting rules gets discarded.
+ *
+ * @param {Rule[]} rules
+ * @param {boolean} recheck Whether we should recursively recheck conflicting
+ *     rules for conflicts even if no good or duplicate rules were found on this
+ *     iteration. Defaults to true.
+ * @returns {Rule[]}
+ */
+function sortedRules(rules, recheck = true) {
+  const newRules = {goodRules: [], conflictingRules: []};
+  let numDiscarded = 0;
+
+  // Move conflicting rules to the end
+  rules.reduce((newRules, currentRule, currentIndex) => {
+    // Check for duplicates between currentRule and the set of conflicting
+    // rules. Discarding duplicate rules needs to take precedence over marking a
+    // rule as conflicting, so we perform this check before anything else.
+    //
+    // The rule that's already been placed in the set of conflictingRules must
+    // have come from a previous index since it's already been processed, so we
+    // discard currentRule.
+    const duplicateRule = newRules.conflictingRules.find(
+        testRule => currentRule.conflictsWith(testRule) &&
+            testRule.conflictsWith(currentRule));
+    if (duplicateRule !== undefined) {
+      numDiscarded++;
+      // Place the currentRule second in this log line so they're numbered in
+      // accordance with their position in the original list. Hopefully that
+      // makes debugging less confusing.
+      console.log(`Rule 1 (${duplicateRule}) and Rule 2 (${
+          currentRule}) both conflict with each other (duplicates?);
+          discarding rule 2 since it came later in the original list
+          (but possibly keeping its audio url)`);
+      if (currentRule.replacement === duplicateRule.replacement &&
+          !duplicateRule.has_audio_url()) {
+        duplicateRule.audio_url = currentRule.audio_url;
+      }
+      // Discard currentRule
+      return;
+    }
+
+    // Check for conflicts with rules that come after this one in the initial
+    // set.
+    for (let i = currentIndex + 1; i < rules.length; i++) {
+      if (currentRule.conflictsWith(rules[i])) {
+        console.log(`Rule 1 (${currentRule}) conflicts with Rule 2 (${
+            rules[i]}); moving first rule to end`)
+        newRules.conflictingRules.push(currentRule);
+        return;
+      }
+
+      // Check for conflicts with rules that have already been marked
+      // conflicting.
+      const conflictingRule = newRules.conflictingRules.find(
+          testRule => currentRule.conflictsWith(testRule));
+      if (conflictingRule !== undefined) {
+        console.log(`Rule 1 (${currentRule}) conflicts with Rule 2 (${
+            conflictingRule}); moving first rule to end`)
+        newRules.conflictingRules.push(currentRule);
+        return;
+      }
+    }
+
+    // No conflict or duplicate discovered!
+    newRules.goodRules.push(currentRule);
+  }, newRules);
+
+  console.log(
+      `On this pass, found ${newRules.conflictingRules.length} conflicting rules
+      and discarded ${numDiscarded} possibly duplicate rules.`);
+
+  if (newRules.conflictingRules.length > 0) {
+    if (newRules.conflictingRules.length < rules.length) {
+      // If we made progress, don't worry about infinite recursion.
+      newRules.conflictingRules = sortedRules(newRules.conflictingRules, true);
+    } else if (recheck) {
+      // If we didn't make progress, try one last time.
+      newRules.conflictingRules = sortedRules(newRules.conflictingRules, false);
+    } else {
+      console.log(
+          `Aborting with ${newRules.conflictingRules.length} conflicts left;
+              unable to reduce further`);
+      console.log(newRules.conflictingRules.map(rule => ruleToString(rule)));
+    }
+  }
+
+  return [...newRules.goodRules, ...newRules.conflictingRules];
+}


### PR DESCRIPTION
This change refactors rules parsing to better encapsulate some of the rules logic. This might be helpful if we ever want to add a feature that re-applies the rules (say, with user-added custom rules, or after the user has manipulating the dom on the page). I also added a feature to sort the rules before applying them, to eliminate conflicts and/or remove duplicates. For example, I now know that on a page with an mdzs work, the mdzs and generic rules combined have 9 conflicts (4 of which were duplicates).

Unfortunately this is a bit slower, especially on a page with a bunch of works, since rules get fetched, parsed, and sorted once per work, even when multiple works have the same (set of) fandoms. Probably would need to finally consolidate that before actually accepting this change. Or maybe just turning off the sorting would be enough?

For funsies this change also adds rule source to the dom (as the data-fandom attribute) because I'm sometimes curious whether a replacement came from a fandom-specific thing, or a generic rule.