### PR TITLE
Fix copy-paste of lines replaced via audio script.

### DIFF
--- a/Tone_Marks_withAudio.pub.user.js
+++ b/Tone_Marks_withAudio.pub.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tone Marks with Audio
 // @namespace    http://tampermonkey.net/
-// @version      4.5
+// @version      4.5.1
 // clang-format off
 // @description  Add tone marks on Ao3 works, and add quick audio guide clips where available
 // @author       Cathalinaheart, irrationalpie7

--- a/audio.css
+++ b/audio.css
@@ -16,7 +16,7 @@
 /* Group audio progress bar with pinyin text. */
 .audio-progress-group {
     position: relative;
-    display: inline;
+    display: inline-block;
 }
 
 /* If applied, hides progress bar except when button is focused or hovered over. */
@@ -30,10 +30,11 @@
 }
 
 .tone-audio-button progress {
-    position: absolute;
-    height: .3em;
-    top: -.15em;
+    height: 0.3em;
+    vertical-align: top;
+    transform: translateY(-.15em);
     width: 100%;
+    margin-right: -100%;
 }
 
 /* Underline just pinyin when hovering over button */

--- a/audio.css
+++ b/audio.css
@@ -33,8 +33,8 @@
     height: 0.3em;
     vertical-align: top;
     transform: translateY(-.15em);
-    width: 100%;
     margin-right: -100%;
+    user-select: none;
 }
 
 /* Underline just pinyin when hovering over button */
@@ -42,8 +42,16 @@
     border-bottom: 1px solid;
 }
 
+.replacement {
+    user-select: text;
+}
+
 .tone-audio-button:focus {
     outline: 1px dotted;
+}
+
+.audio-guide {
+    user-select: none;
 }
 
 /* Override icon font size/placement */

--- a/audio.css
+++ b/audio.css
@@ -10,12 +10,13 @@
     box-shadow: none;
     vertical-align: baseline;
     border-radius: 0;
-    display: inline-flex;
+    display: inline;
 }
 
 /* Group audio progress bar with pinyin text. */
 .audio-progress-group {
     position: relative;
+    display: inline;
 }
 
 /* If applied, hides progress bar except when button is focused or hovered over. */

--- a/audio.js
+++ b/audio.js
@@ -19,6 +19,7 @@ function addAudioButtonAround(span) {
   progress.classList.add('inactive-audio-progress-bar');
   progress.ariaLabel = 'Audio playback percent';
   progressGroup.appendChild(progress);
+  progress.setAttribute('style', 'width:' + span.offsetWidth + 'px');
 
   // Wrap the pinyin span in a button:
   // First, replace, so the original parent still knows *where* to put the
@@ -69,4 +70,6 @@ function addAudioButtonAround(span) {
       audio.pause();
     }
   });
+
+  // Set progress bar width:
 }


### PR DESCRIPTION
I noticed yesterday when copying text from an ao3 fic that had the audio tone marks script running, that the pasted text had extra new lines around the replaced text. (e.g., "text Lán Wàngjī text" would become "text \nLán Wàngjī\n text", with the \n's expanded).

After this change, that should no longer be the case. As a bonus, you can also now triple-click a paragraph (anywhere but a button) to select the whole paragraph, whereas before that would only select the portion of the paragraph between two consecutive buttons.